### PR TITLE
Working Apply 2-body operations to FCIComp.

### DIFF
--- a/sandbox/benchmarking/bmk_apply_012bdy_v1.py
+++ b/sandbox/benchmarking/bmk_apply_012bdy_v1.py
@@ -1,0 +1,97 @@
+import qforte as qf
+ 
+import time
+
+# Define the reference and geometry lists.
+geom = [
+    ('H', (0., 0., 1.0)), 
+    ('H', (0., 0., 2.0)),
+    ('H', (0., 0., 3.0)), 
+    ('H', (0., 0., 4.0)),
+    ('H', (0., 0., 5.0)), 
+    ('H', (0., 0., 6.0)),
+    ('H', (0., 0., 7.0)), 
+    ('H', (0., 0., 8.0)),
+    # ('H', (0., 0., 9.0)), 
+    # ('H', (0., 0.,10.0))
+    ]
+
+# Get the molecule object that now contains both the fermionic and qubit Hamiltonians.
+mol = qf.system_factory(build_type='psi4', mol_geometry=geom, basis='sto-3g')
+ 
+print("\n Initial FCIcomp Stuff")
+print("===========================")
+ref = mol.hf_reference
+
+nel = sum(ref)
+sz = 0
+norb = int(len(ref) / 2)
+
+print(f" nqbit:     {norb*2}")
+print(f" nel:       {nel}")
+ 
+fci_comp = qf.FCIComputer(nel=nel, sz=sz, norb=norb)
+fci_comp.hartree_fock()
+ 
+fock_comp = qf.Computer(norb * 2)
+
+Uhf = qf.utils.state_prep.build_Uprep(ref, 'occupation_list')
+fock_comp.apply_circuit(Uhf)
+ 
+qb_ham = mol.sq_hamiltonian.jw_transform()
+ 
+dim = 2*norb
+max_nbody = 2
+ 
+Top = qf.TensorOperator(
+    max_nbody = max_nbody,
+    dim = dim
+    )
+ 
+print("\n SQOP Stuff")
+print("===========================")
+sq0, sq1, sq2 = mol.sq_hamiltonian.split_by_rank(False)
+# sqop = qf.SQOperator()
+# sqop.add_op(sq1)
+# sqop.add_op(sq2)
+ 
+t_ap012bdy_fock = time.perf_counter()
+# fock_comp.apply_sq_operator(mol.sq_hamiltonian)
+# fock_comp.apply_operator(qb_ham)
+Eo_fock = fock_comp.direct_op_exp_val(qb_ham)
+t_ap012bdy_fock = time.perf_counter() - t_ap012bdy_fock
+
+ 
+# so all seems to be working except
+print("\n Tensor Stuff")
+print("===========================")
+Top.add_sqop_of_rank(sq0, 0)
+Top.add_sqop_of_rank(sq1, 2)
+Top.add_sqop_of_rank(sq2, 4)
+ 
+[H0, H1, H2] = Top.tensors()
+ 
+# print(H1)
+ 
+t_ap012bdy_fci = time.perf_counter()
+fci_comp.apply_tensor_spin_012bdy(H0, H1, H2, norb)
+Eo_fci = fci_comp.get_hf_dot() 
+t_ap012bdy_fci = time.perf_counter() - t_ap012bdy_fci
+ 
+if(norb < 6): 
+    print("\n Final FCIcomp Stuff")
+    print("===========================")
+    print(fci_comp)
+
+    print("\n Final FockComp Stuff")
+    print("===========================")
+    print(fock_comp)
+ 
+print("\n Timing")
+print("======================================================")
+print(f" nqbit:     {norb*2}")
+print(f" fci_time:  {t_ap012bdy_fci:12.8f}")
+print(f" fock_time: {t_ap012bdy_fock:12.8f}")
+print(f" speedup:   {(t_ap012bdy_fock/t_ap012bdy_fci):12.8f}")
+print(f" Eo fock:   {Eo_fock}")
+print(f" Eo fci:    {Eo_fci}")

--- a/sandbox/benchmarking/bmk_apply_12bdy_v1.py
+++ b/sandbox/benchmarking/bmk_apply_12bdy_v1.py
@@ -1,0 +1,91 @@
+import qforte as qf
+ 
+import time
+
+# Define the reference and geometry lists.
+geom = [
+    ('H', (0., 0., 1.0)), 
+    ('H', (0., 0., 2.0)),
+    ('H', (0., 0., 3.0)), 
+    ('H', (0., 0., 4.0)),
+    ('H', (0., 0., 5.0)), 
+    ('H', (0., 0., 6.0)),
+    ('H', (0., 0., 7.0)), 
+    ('H', (0., 0., 8.0)),
+    # ('H', (0., 0., 9.0)), 
+    # ('H', (0., 0.,10.0))
+    ]
+
+# Get the molecule object that now contains both the fermionic and qubit Hamiltonians.
+mol = qf.system_factory(build_type='psi4', mol_geometry=geom, basis='sto-3g')
+ 
+print("\n Initial FCIcomp Stuff")
+print("===========================")
+ref = mol.hf_reference
+
+nel = sum(ref)
+sz = 0
+norb = int(len(ref) / 2)
+
+print(f" nqbit:     {norb*2}")
+print(f" nel:       {nel}")
+ 
+fci_comp = qf.FCIComputer(nel=nel, sz=sz, norb=norb)
+fci_comp.hartree_fock()
+ 
+fock_comp = qf.Computer(norb * 2)
+
+Uhf = qf.utils.state_prep.build_Uprep(ref, 'occupation_list')
+fock_comp.apply_circuit(Uhf)
+ 
+# print(fci_comp.str(print_data=True))
+ 
+dim = 2*norb
+max_nbody = 2
+ 
+Top = qf.TensorOperator(
+    max_nbody = max_nbody,
+    dim = dim
+    )
+ 
+print("\n SQOP Stuff")
+print("===========================")
+sq0, sq1, sq2 = mol.sq_hamiltonian.split_by_rank(False)
+sqop = qf.SQOperator()
+sqop.add_op(sq1)
+sqop.add_op(sq2)
+ 
+t_ap12bdy_fock = time.perf_counter()
+fock_comp.apply_sq_operator(sqop)
+t_ap12bdy_fock = time.perf_counter() - t_ap12bdy_fock
+
+ 
+# so all seems to be working except
+print("\n Tensor Stuff")
+print("===========================")
+Top.add_sqop_of_rank(sq1, 2)
+Top.add_sqop_of_rank(sq2, 4)
+ 
+[H0, H1, H2] = Top.tensors()
+ 
+# print(H1)
+ 
+t_ap12bdy_fci = time.perf_counter()
+fci_comp.apply_tensor_spin_12bdy(H1, H2, norb)
+t_ap12bdy_fci = time.perf_counter() - t_ap12bdy_fci
+ 
+if(norb < 6): 
+    print("\n Final FCIcomp Stuff")
+    print("===========================")
+    print(fci_comp)
+
+    print("\n Final FockComp Stuff")
+    print("===========================")
+    print(fock_comp)
+ 
+print("\n Timing")
+print("======================================================")
+print(f" nqbit:     {norb*2}")
+print(f" fci_time:  {t_ap12bdy_fci:12.8f}")
+print(f" fock_time: {t_ap12bdy_fock:12.8f}")
+print(f" speedup:   {(t_ap12bdy_fock/t_ap12bdy_fci):12.8f}")

--- a/sandbox/benchmarking/bmk_apply_1bdy_v1.py
+++ b/sandbox/benchmarking/bmk_apply_1bdy_v1.py
@@ -1,0 +1,69 @@
+import qforte as qf
+ 
+import time
+ 
+print("\n Initial FCIcomp Stuff")
+print("===========================")
+nel = 6
+sz = 0
+norb = 6
+ 
+fci_comp = qf.FCIComputer(nel=nel, sz=sz, norb=norb)
+fci_comp.hartree_fock()
+ 
+fock_comp = qf.Computer(norb * 2)
+ 
+# print(fci_comp.str(print_data=True))
+ 
+dim = 2*norb
+max_nbody = 1
+ 
+Top = qf.TensorOperator(
+    max_nbody = max_nbody,
+    dim = dim
+    )
+ 
+print("\n SQOP Stuff")
+print("===========================")
+sqop = qf.SQOperator()
+ 
+# sqop.add_term(2.0, [5], [1])
+# sqop.add_term(2.0, [1], [5])
+ 
+# sqop.add_term(2.0, [4], [0])
+# sqop.add_term(2.0, [0], [4])
+ 
+for i in range(norb*2):
+    for j in range(norb*2):
+        sqop.add_term(2.0+i-j, [i], [j])
+        sqop.add_term(2.0+i-j, [j], [i])
+ 
+# print(sqop)
+ 
+t_ap1bdy_fock = time.perf_counter()
+fock_comp.apply_sq_operator(sqop)
+t_ap1bdy_fock = time.perf_counter() - t_ap1bdy_fock
+ 
+# so all seems to be working except
+print("\n Tensor Stuff")
+print("===========================")
+Top.add_sqop_of_rank(sqop, sqop.ranks_present()[0])
+ 
+[H0, H1] = Top.tensors()
+ 
+# print(H1)
+ 
+t_ap1bdy_fci = time.perf_counter()
+fci_comp.apply_tensor_spin_1bdy(H1, norb)
+t_ap1bdy_fci = time.perf_counter() - t_ap1bdy_fci
+ 
+# print("\n Final FCIcomp Stuff")
+# print("===========================")
+# print(fci_comp)
+ 
+print("\n Timing")
+print("======================================================")
+print(f" nqbit:     {norb*2}")
+print(f" fci_time:  {t_ap1bdy_fci:12.8f}")
+print(f" fock_time: {t_ap1bdy_fock:12.8f}")
+print(f" speedup:   {(t_ap1bdy_fock/t_ap1bdy_fci):12.8f}")

--- a/sandbox/fci_computer/test_apply_spin_12bdy_v1.py
+++ b/sandbox/fci_computer/test_apply_spin_12bdy_v1.py
@@ -1,0 +1,62 @@
+import qforte as qf
+
+print("\n Initial FCIcomp Stuff")
+print("===========================")
+nel = 4
+sz = 0
+norb = 4
+
+fci_comp = qf.FCIComputer(nel=nel, sz=sz, norb=norb)
+fci_comp.hartree_fock()
+
+print(fci_comp.str(print_data=True))
+
+dim = 2*norb
+max_nbody = 2
+
+Top = qf.TensorOperator(
+    max_nbody = max_nbody, 
+    dim = dim
+    )
+
+print("\n SQOP Stuff")
+print("===========================")
+sqop1 = qf.SQOperator()
+sqop2 = qf.SQOperator()
+sqop1.add_term(2.0, [5], [1])
+sqop1.add_term(2.0, [1], [5])
+
+sqop1.add_term(2.0, [4], [0])
+sqop1.add_term(2.0, [0], [4])
+
+sqop2.add_term(4.5, [5, 4], [1, 0])
+sqop2.add_term(4.5, [0, 1], [4, 5])
+
+print(sqop1)
+print(sqop2)
+
+# so all seems to be working except 
+print("\n Tensor Stuff")
+print("===========================")
+print(f"Ranks present2: {sqop2.ranks_present()}")
+
+Top.add_sqop_of_rank(sqop1, 2)
+Top.add_sqop_of_rank(sqop2, 4)
+
+[H0, H1, H2] = Top.tensors()
+
+# print(H1)
+
+# fci_comp.apply_tensor_spin_1bdy(H1, norb)
+
+# print("\n Final FCIcomp 1-body Stuff")
+# print("================================")
+# print(fci_comp)
+
+
+fci_comp.hartree_fock()
+fci_comp.apply_tensor_spin_12bdy(H1, H2, norb)
+
+print("\n Final FCIcomp 12-body Stuff")
+print("=================================")
+print(fci_comp)

--- a/sandbox/tensor/test_slice_v1.py
+++ b/sandbox/tensor/test_slice_v1.py
@@ -1,0 +1,17 @@
+import qforte as qf
+
+shape = [5, 5]
+
+t1 = qf.Tensor(shape, "Tensor 1")
+
+for i in range(shape[0]):
+    for j in range(shape[1]):
+        t1.set([i, j], i + j)
+
+print(t1)
+
+            # (include, exclude)
+
+t2 = t1.slice([(2, 3), (2, 3)])
+
+print(t2)

--- a/sandbox/tensor_einsum/test_permute_v2.py
+++ b/sandbox/tensor_einsum/test_permute_v2.py
@@ -1,0 +1,50 @@
+import qforte as qf
+import numpy as np
+import re
+
+# Set the seed value
+seed_value = 42
+np.random.seed(seed_value)
+
+# Generate a random NumPy array
+array_shape = (2, 2, 2, 2)  # Specify the shape of the array
+random_array = np.random.rand(*array_shape)
+
+shape1 = [2, 2, 2, 2]
+axes = [0, 2, 1, 3]
+
+# random_arrayT = random_array.transpose(axes)
+random_arrayT = np.moveaxis(random_array, 1, 2) * (-1.0)
+print("\n")
+print(random_arrayT)
+print("\n")
+
+T1 = qf.Tensor(shape=shape1, name='steve')
+for i in range(shape1[0]):
+    for j in range(shape1[1]):
+        for k in range(shape1[2]):
+            for l in range(shape1[3]):
+                T1.set([i,j,k,l], random_array[i,j,k,l])
+
+T3 = T1.general_transpose(axes)
+
+# print(T3)
+
+# want to use permute to do this same operation 
+permstr = 'ijkl->ikjl'
+Astr, Cstr = re.split(r'->', permstr)
+Tcontainer = qf.Tensor(shape=T3.shape(), name='Tcontainer')
+print(f"{Astr}, {Cstr}")
+
+qf.Tensor.permute(
+    [x for x in Astr],  
+    [x for x in Cstr], 
+    T1, 
+    Tcontainer,
+    1.0,
+    0.0)
+
+Tcontainer.scale(-1.0)
+
+print(Tcontainer)
+

--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -201,6 +201,9 @@ PYBIND11_MODULE(qforte, m) {
         .def(py::init<int, int, int>(), "nel"_a, "sz"_a, "norb"_a, "Make a FCIComputer with nel, sz, and norb")
         .def("hartree_fock", &FCIComputer::hartree_fock)
         .def("apply_tensor_spin_1bdy", &FCIComputer::apply_tensor_spin_1bdy)
+        .def("apply_tensor_spin_12bdy", &FCIComputer::apply_tensor_spin_12bdy)
+        .def("apply_tensor_spin_012bdy", &FCIComputer::apply_tensor_spin_012bdy)
+        .def("get_hf_dot", &FCIComputer::get_hf_dot)
         .def("str", &FCIComputer::str, 
             py::arg("print_data") = true, 
             py::arg("print_complex") = false)
@@ -236,6 +239,7 @@ PYBIND11_MODULE(qforte, m) {
         .def("shape", &Tensor::shape)
         .def("strides", &Tensor::strides)
         .def("set", &Tensor::set)
+        .def("add_to_element", &Tensor::add_to_element)
         .def("get", &Tensor::get)
         .def("fill_from_np", &Tensor::fill_from_np)
         .def("add", &Tensor::add) // TODO(Tyler) Need Test (use numpy)

--- a/src/qforte/fci_computer.cc
+++ b/src/qforte/fci_computer.cc
@@ -116,6 +116,285 @@ void FCIComputer::apply_tensor_spin_1bdy(const Tensor& h1e, size_t norb) {
     C_ = Cnew;
 }
 
+/// apply Tensors represending 1-body and 2-body spin-orbital indexed operator to the current state 
+/// A LOT of wasted memory here, will want to improve...
+void FCIComputer::apply_tensor_spin_12bdy(
+    const Tensor& h1e, 
+    const Tensor& h2e, 
+    size_t norb) 
+{
+    if(norb > 10 or norb_ > 10){
+        throw std::invalid_argument("Don't use this function with more that 10 orbitals, too much memory");
+    }
+
+    if(h1e.size() != (norb * 2) * (norb * 2)){
+        throw std::invalid_argument("Expecting h1e to be nso x nso for apply_tensor_spin_12bdy");
+    }
+
+    if(h2e.size() != (norb * 2) * (norb * 2) * (norb * 2) * (norb * 2) ){
+        throw std::invalid_argument("Expecting h2e to be nso x nso x nso nso for apply_tensor_spin_12bdy");
+    }
+
+    Tensor Cnew({nalfa_strs_, nbeta_strs_}, "Cnew");
+    Tensor h1e_new = h1e;
+
+    Tensor h2e_new(h2e.shape(), "A2");
+    Tensor::permute(
+        {"i", "j", "k", "l"}, 
+        {"i", "k", "j", "l"}, 
+        h2e, 
+        h2e_new); 
+
+    h2e_new.scale(-1.0);
+
+    for(int k = 0; k < 2 * norb_; k++){
+        Tensor h2e_k = h2e.slice(
+        {
+            std::make_pair(0, 2 * norb_), 
+            std::make_pair(k, k+1),
+            std::make_pair(k, k+1), 
+            std::make_pair(0, 2 * norb_)
+            }
+        );
+
+        h2e_k.scale(-1.0);
+
+        h1e_new.zaxpy(
+            h2e_k,
+            1.0,
+            1,
+            1);
+    }
+
+    /// NICK: Keeping this here in case future debuggin is needed
+    // 1 std::cout << "\n\n  ====> h1e <====" << h1e_new.print_nonzero() << std::endl;
+    // 1 std::cout << "\n\n  ====> h2e <====" << h2e_new.print_nonzero() << std::endl;
+
+    Tensor h1e_blk1 = h1e_new.slice(
+        {
+            std::make_pair(0, norb_), 
+            std::make_pair(0, norb_)
+            }
+        );
+
+    Tensor h1e_blk2 = h1e_new.slice(
+        {
+            std::make_pair(norb_, 2*norb_), 
+            std::make_pair(norb_, 2*norb_)
+            }
+        );
+
+    Tensor h2e_blk11 = h2e_new.slice(
+        {
+            std::make_pair(0, norb_), 
+            std::make_pair(0, norb_),
+            std::make_pair(0, norb_), 
+            std::make_pair(0, norb_)
+            }
+        );
+
+    Tensor h2e_blk12 = h2e_new.slice(
+        {
+            std::make_pair(0, norb_), 
+            std::make_pair(0, norb_),
+            std::make_pair(norb_, 2*norb_), 
+            std::make_pair(norb_, 2*norb_)
+            }
+        );
+
+    Tensor h2e_blk21 = h2e_new.slice(
+        {
+            std::make_pair(norb_, 2*norb_), 
+            std::make_pair(norb_, 2*norb_),
+            std::make_pair(0, norb_), 
+            std::make_pair(0, norb_)
+            }
+        );
+
+    Tensor h2e_blk22 = h2e_new.slice(
+        {
+            std::make_pair(norb_, 2*norb_), 
+            std::make_pair(norb_, 2*norb_),
+            std::make_pair(norb_, 2*norb_), 
+            std::make_pair(norb_, 2*norb_)
+            }
+        );
+
+    std::pair<Tensor, Tensor> dvec = calculate_dvec_spin_with_coeff();
+    
+    Tensor dveca_new(dvec.first.shape(),  "dveca_new");
+    Tensor dvecb_new(dvec.second.shape(), "dvecb_new");
+
+    Tensor::einsum(
+        {"i", "j"},
+        {"i", "j", "k", "l"},
+        {"k", "l"},
+        h1e_blk1,
+        dvec.first,
+        Cnew, 
+        1.0,
+        0.0
+    );
+
+    Tensor::einsum(
+        {"i", "j"},
+        {"i", "j", "k", "l"},
+        {"k", "l"},
+        h1e_blk2,
+        dvec.second,
+        Cnew, 
+        1.0,
+        0.0
+    );
+
+    Tensor::einsum(
+        {"i", "j", "k", "l"},
+        {"k", "l", "m", "n"},
+        {"i", "j", "m", "n"},
+        h2e_blk11,
+        dvec.first,
+        dveca_new, 
+        1.0,
+        0.0
+    );
+
+    Tensor::einsum(
+        {"i", "j", "k", "l"},
+        {"k", "l", "m", "n"},
+        {"i", "j", "m", "n"},
+        h2e_blk12,
+        dvec.second,
+        dveca_new, 
+        1.0,
+        0.0
+    );
+
+    Tensor::einsum(
+        {"i", "j", "k", "l"},
+        {"k", "l", "m", "n"},
+        {"i", "j", "m", "n"},
+        h2e_blk21,
+        dvec.first,
+        dvecb_new, 
+        1.0,
+        0.0
+    );
+
+    Tensor::einsum(
+        {"i", "j", "k", "l"},
+        {"k", "l", "m", "n"},
+        {"i", "j", "m", "n"},
+        h2e_blk22,
+        dvec.second,
+        dvecb_new, 
+        1.0,
+        0.0
+    );
+
+    std::pair<Tensor, Tensor> dvec_new = std::make_pair(dveca_new, dvecb_new);
+
+    Cnew.zaxpy(
+        calculate_coeff_spin_with_dvec(dvec_new),
+        1.0,
+        1,
+        1    
+    );
+
+    C_ = Cnew;
+}
+
+/// apply Tensors represending 1-body and 2-body spin-orbital indexed operator to the current state 
+void FCIComputer::apply_tensor_spin_012bdy(
+    const Tensor& h0e, 
+    const Tensor& h1e, 
+    const Tensor& h2e, 
+    size_t norb) 
+{
+    h0e.shape_error({1});
+    Tensor Czero = C_;
+    
+    apply_tensor_spin_12bdy(
+        h1e,
+        h2e,
+        norb);
+
+    C_.zaxpy(
+        Czero,
+        h0e.get({0}),
+        1,
+        1    
+    );
+}
+
+// NICK: VERY VERY Slow, will want even a better c++ implementation!
+// Try with einsum once working or perhaps someting like the above...
+std::pair<Tensor, Tensor> FCIComputer::calculate_dvec_spin_with_coeff() {
+
+    Tensor dveca({norb_, norb_, nalfa_strs_, nbeta_strs_}, "dveca");
+    Tensor dvecb({norb_, norb_, nalfa_strs_, nbeta_strs_}, "dvecb");
+
+    for (size_t i = 0; i < norb_; ++i) {
+        for (size_t j = 0; j < norb_; ++j) {
+            auto alfa_mappings = graph_.get_alfa_map()[std::make_pair(i,j)];
+            auto beta_mappings = graph_.get_beta_map()[std::make_pair(i,j)];
+
+            for (const auto& mapping : alfa_mappings) {
+                size_t source = std::get<0>(mapping);
+                size_t target = std::get<1>(mapping);
+                std::complex<double> parity = static_cast<std::complex<double>>(std::get<2>(mapping));
+                for (size_t k = 0; k < dveca.shape()[3]; ++k) {
+                    std::complex<double> val = dveca.get({i,j,target,k}) + C_.get({source, k}) * parity;
+                    dveca.set({i,j,target,k}, val);
+                }
+            }
+
+            for (const auto& mapping : beta_mappings) {
+                size_t source = std::get<0>(mapping);
+                size_t target = std::get<1>(mapping);
+                std::complex<double> parity = static_cast<std::complex<double>>(std::get<2>(mapping));
+                for (size_t k = 0; k < dvecb.shape()[2]; ++k) {
+                    std::complex<double> val = dvecb.get({i,j,k,target}) + C_.get({k, source}) * parity;
+                    dvecb.set({i,j,k,target}, val);
+                }
+            }
+        }
+    }
+    return std::make_pair(dveca, dvecb);
+}
+
+// ALSO VERY SLOW
+Tensor FCIComputer::calculate_coeff_spin_with_dvec(std::pair<Tensor, Tensor>& dvec) {
+    Tensor Cnew({nalfa_strs_, nbeta_strs_}, "Cnew");
+
+    for (size_t i = 0; i < norb_; ++i) {
+        for (size_t j = 0; j < norb_; ++j) {
+
+            auto alfa_mappings = graph_.get_alfa_map()[std::make_pair(j,i)];
+            auto beta_mappings = graph_.get_beta_map()[std::make_pair(j,i)];
+
+            for (const auto& mapping : alfa_mappings) {
+                size_t source = std::get<0>(mapping);
+                size_t target = std::get<1>(mapping);
+                std::complex<double> parity = static_cast<std::complex<double>>(std::get<2>(mapping));
+                for (size_t k = 0; k < dvec.first.shape()[3]; ++k) {
+                    Cnew.add_to_element({source, k}, dvec.first.get({i,j,target,k}) * parity);
+                }
+                
+            }
+            for (const auto& mapping : beta_mappings) {
+                size_t source = std::get<0>(mapping);
+                size_t target = std::get<1>(mapping);
+                std::complex<double> parity = static_cast<std::complex<double>>(std::get<2>(mapping));
+                for (size_t k = 0; k < dvec.second.shape()[2]; ++k) {
+                    Cnew.add_to_element({k, source}, dvec.second.get({i,j,k,target}) * parity);
+                }
+            }
+        }
+    }
+
+    return Cnew;
+}
+
 void FCIComputer::apply_array_1bdy(
     Tensor& out,
     const std::vector<int>& dexc,

--- a/src/qforte/fci_computer.h
+++ b/src/qforte/fci_computer.h
@@ -44,6 +44,17 @@ class FCIComputer {
       const Tensor& h1e, 
       size_t norb);
 
+    void apply_tensor_spin_12bdy(
+      const Tensor& h1e, 
+      const Tensor& h2e, 
+      size_t norb);
+
+    void apply_tensor_spin_012bdy(
+      const Tensor& h0e, 
+      const Tensor& h1e, 
+      const Tensor& h2e, 
+      size_t norb);
+
     void lm_apply_array1(
       // const double complex *coeff, don't need
       // double complex *out,
@@ -68,6 +79,10 @@ class FCIComputer {
       const Tensor& h1e,
       const int norbs,
       const bool is_alpha);
+
+    std::pair<Tensor, Tensor> calculate_dvec_spin_with_coeff();
+
+    Tensor calculate_coeff_spin_with_dvec(std::pair<Tensor, Tensor>& dvec);
 
     /// apply a 1-body and 2-body TensorOperator to the current state 
     void apply_tensor_spin_12_body(const TensorOperator& top);
@@ -106,7 +121,10 @@ class FCIComputer {
     }
 
     /// return a tensor of the coeficients
-    Tensor get_state() const { return C_; };
+    Tensor get_state() const { return C_; }
+
+    /// return the dot product of the current FCIComputer state (as the ket) and the HF state (i.e. <HF|C_>)
+    std::complex<double> get_hf_dot() const { return C_.get({0,0}); }
 
     /// return the coefficient corresponding to a alpha-basis / beta-basis 
     std::complex<double> coeff(const QubitBasis& abasis, const QubitBasis& bbasis);

--- a/src/qforte/tensor.h
+++ b/src/qforte/tensor.h
@@ -100,6 +100,11 @@ void set(const std::vector<size_t>& idxs,
          const std::complex<double> val
          );
 
+/// Set a particular element of tis Tensor, specified by idxs
+void add_to_element(const std::vector<size_t>& idxs,
+         const std::complex<double> val
+         );
+
 /// Get a particular element of tis Tensor, specified by idxs
 std::complex<double> get(const std::vector<size_t>& idxs) const;
 
@@ -228,6 +233,9 @@ std::string str(
     const std::string& data_format = "%12.7f",
     const std::string& header_format = "%12zu"
     ) const; 
+
+
+std::string print_nonzero() const;
 
 /**
  * Fill a tensor from a Numpy Array

--- a/src/qforte/tensor_einsum.cc
+++ b/src/qforte/tensor_einsum.cc
@@ -576,7 +576,15 @@ void Tensor::permute( /// NICK: will try replacement only model here
 
     /// NICK: This seems to work but is obviously super wasteful, 
     /// May want to revise.
-    C2 = C;
+    // C2 = C;
+
+    C2.zaxpy(
+        C,
+        1.0,
+        1,
+        1    
+    );
+
     return;
 } // Well, it compiles at least!
 
@@ -1128,7 +1136,7 @@ void Tensor::einsum(
             }
         } else {
             // C_DGEMM(Ltrans, Rtrans, nrow, ncol, nzip, alpha, Lp, Llda, Rp, Rlda, beta, C2p, Clda);
-            std::cout << "I get to zgemm!" << std::endl;
+            // std::cout << "I get to zgemm!" << std::endl;
 
             math_zgemm(
                 Ltrans, 
@@ -1156,7 +1164,13 @@ void Tensor::einsum(
     if (Cperm) {
         Tensor::permute(Cinds2, Cinds, C2, C3);
     } else {
-        C3 = C2;
+        // C3 = C2;
+        C3.zaxpy(
+            C2,
+            1.0,
+            1,
+            1    
+        );
     }
 
 }


### PR DESCRIPTION
## Description
This PR adds the ability to apply 2-body operators (as tensors) to a FCIComputer object. It can successfully reproduce HF energies by applying the molecular hamiltonian and is ~50x faster (for 10+ electrons) than the standard JW transformed Hamiltonian. 

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [ ] Ready to go!
