### PR TITLE
Adds ability to apply (not evolve) df hamiltonian to a FCIComputer.

### DIFF
--- a/sandbox/benchmarking/bmk_apply_1bdy_spat_v1.py
+++ b/sandbox/benchmarking/bmk_apply_1bdy_spat_v1.py
@@ -1,0 +1,117 @@
+import qforte as qf
+import numpy as np
+ 
+import time
+
+# Define the reference and geometry lists.
+geom = [
+    ('H', (0., 0., 1.0)), 
+    ('H', (0., 0., 2.0)),
+    ('H', (0., 0., 3.0)), 
+    ('H', (0., 0., 4.0)),
+    # ('H', (0., 0., 5.0)), 
+    # ('H', (0., 0., 6.0)),
+    # ('H', (0., 0., 7.0)), 
+    # ('H', (0., 0., 8.0)),
+    # ('H', (0., 0., 9.0)), 
+    # ('H', (0., 0.,10.0)),
+    # ('H', (0., 0.,11.0)), 
+    # ('H', (0., 0.,12.0))
+    ]
+
+
+# geom = [
+#     ('H', (0., 0., 1.0)), 
+#     ('Be', (0., 0., 2.0)),
+#     ('H', (0., 0., 3.0)), 
+#     ]
+
+# geom = [('Li', [0.0, 0.0, 0.0]), ('H', [0.0, 0.0, 1.45])]
+
+# Get the molecule object that now contains both the fermionic and qubit Hamiltonians.
+mol = qf.system_factory(
+    build_type='psi4', 
+    mol_geometry=geom, 
+    basis='sto-3g', 
+    build_qb_ham = False, 
+    run_fci=1,
+    store_mo_ints=1,
+    build_df_ham=1,  # NOTE(for Victor): Need to do in order build  df_ham
+    df_icut=1.0e-10)
+ 
+print("\n Initial FCIcomp Stuff")
+print("===========================")
+ref = mol.hf_reference
+
+nel = sum(ref)
+sz = 0
+norb = int(len(ref) / 2)
+
+print(f" nqbit:     {norb*2}")
+print(f" nel:       {nel}")
+ 
+fc1 = qf.FCIComputer(nel=nel, sz=sz, norb=norb)
+fc2 = qf.FCIComputer(nel=nel, sz=sz, norb=norb)
+fc1.hartree_fock()
+fc2.hartree_fock()
+
+rand = True
+if(rand):
+    np.random.seed(11)
+    random_array = np.random.rand(fc1.get_state().shape()[0], fc1.get_state().shape()[1])
+    random = np.array(random_array, dtype = np.dtype(np.complex128))
+    Crand = qf.Tensor(fc1.get_state().shape(), "Crand")
+    Crand.fill_from_nparray(random.ravel(), Crand.shape())
+    rand_nrm = Crand.norm()
+    Crand.scale(1/rand_nrm)
+    fc1.set_state(Crand)
+    fc2.set_state(Crand)
+ 
+dim = 2*norb
+max_nbody = 2
+ 
+Top = qf.TensorOperator(
+    max_nbody = max_nbody,
+    dim = dim
+    )
+ 
+print("\n SQOP Stuff")
+print("===========================")
+sq0, sq1, sq2 = mol.sq_hamiltonian.split_by_rank(False)
+ 
+# so all seems to be working except
+print("\n Tensor Stuff")
+print("===========================")
+Top.add_sqop_of_rank(sq0, 0)
+Top.add_sqop_of_rank(sq1, 2)
+Top.add_sqop_of_rank(sq2, 4)
+ 
+[H0, H1spin, H2] = Top.tensors()
+# print(H1spin)
+
+# get one body spatial tensor:
+# H1spat = mol.mo_oeis # augmented ...
+H1spat = mol.df_ham.get_one_body_ints()
+# print(H1spat)
+ 
+
+# fc1.apply_tensor_spin_012bdy(H0, H1, H2, norb)
+fc1.apply_sqop(sq1)
+fc2.apply_tensor_spat_1bdy(H1spat, norb)
+
+
+E1 = np.real(fc1.get_hf_dot()) 
+E2 = np.real(fc2.get_hf_dot()) 
+
+ 
+if(norb < 6): 
+    print("\n Final FCIcomp Stuff")
+    print("===========================")
+    print(fc1)
+    print(fc2)
+ 
+print("\n Result")
+print("======================================================")
+print(f" nqbit:     {norb*2}")
+print(f" E1:        {E1:6.10f}")
+print(f" E2:        {E2:6.10f}")

--- a/sandbox/sqop_pool/test_app_df_ham_v1.py
+++ b/sandbox/sqop_pool/test_app_df_ham_v1.py
@@ -1,0 +1,117 @@
+import qforte as qf
+import numpy as np
+
+
+# Define the reference and geometry lists.
+geom = [
+    ('H', (0., 0., 1.0)), 
+    ('H', (0., 0., 2.0)),
+    ('H', (0., 0., 3.0)), 
+    ('H', (0., 0., 4.0)),
+    ('H', (0., 0., 5.0)), 
+    ('H', (0., 0., 6.0)),
+    ('H', (0., 0., 7.0)), 
+    ('H', (0., 0., 8.0)),
+    ('H', (0., 0., 9.0)), 
+    ('H', (0., 0.,10.0)),
+    # ('H', (0., 0.,11.0)), 
+    # ('H', (0., 0.,12.0))
+    ]
+
+
+# geom = [
+#     ('H', (0., 0., 1.0)), 
+#     ('Be', (0., 0., 2.0)),
+#     ('H', (0., 0., 3.0)), 
+#     ]
+
+# geom = [('Li', [0.0, 0.0, 0.0]), ('H', [0.0, 0.0, 1.45])]
+
+tmr = qf.local_timer()
+
+tmr.reset()
+# Get the molecule object that now contains both the fermionic and qubit Hamiltonians.
+mol = qf.system_factory(
+    build_type='psi4', 
+    mol_geometry=geom, 
+    basis='sto-3g', 
+    build_qb_ham = False, 
+    run_fci=1,
+    store_mo_ints=1,
+    build_df_ham=1,  # NOTE(for Victor): Need to do in order build  df_ham
+    df_icut=0.001)
+
+tmr.record("psi4 setup")
+
+sq_ham = mol.sq_hamiltonian
+ 
+print("\n Initial FCIcomp Stuff")
+print("===========================")
+ref = mol.hf_reference
+
+nel = sum(ref)
+sz = 0 
+norb = int(len(ref) / 2)
+
+print(f" nqbit:     {norb*2}")
+print(f" nel:       {nel}")
+ 
+fc1 = qf.FCIComputer(nel=nel, sz=sz, norb=norb)
+fc1.hartree_fock()
+
+fc2 = qf.FCIComputer(nel=nel, sz=sz, norb=norb)
+fc2.hartree_fock()
+
+rand = False
+if(rand):
+    random_array = np.random.rand(fc1.get_state().shape()[0], fc1.get_state().shape()[1])
+    random = np.array(random_array, dtype = np.dtype(np.complex128))
+    Crand = qf.Tensor(fc1.get_state().shape(), "Crand")
+    Crand.fill_from_nparray(random.ravel(), Crand.shape())
+    rand_nrm = Crand.norm()
+    Crand.scale(1/rand_nrm)
+    fc1.set_state(Crand)
+    fc2.set_state(Crand)
+
+dt = 1.0
+
+# NOTE(for Victor): Must scale the first leaf with dt!
+qf.helper.df_ham_helper.time_scale_first_leaf(mol.df_ham, dt)
+v_lst = mol.df_ham.get_scaled_density_density_matrices()
+gt_lst = mol.df_ham.get_trotter_basis_change_matrices()
+g_lst = mol.df_ham.get_basis_change_matrices()
+
+print(f"\nnorb {len(geom)} len v_lst {len(v_lst)} len g_lst {len(g_lst)} en gt_lst {len(gt_lst)}\n")
+
+
+
+tmr.reset()
+fc1.apply_sqop(mol.sq_hamiltonian)
+tmr.record("apply sq ham")
+
+tmr.reset()
+fc2.apply_df_ham(mol.df_ham, mol.nuclear_repulsion_energy)
+tmr.record("apply df ham")
+
+E1 = np.real(fc1.get_hf_dot())
+E2 = np.real(fc2.get_hf_dot())
+
+C1 = fc1.get_state_deep()
+C2 = fc2.get_state_deep()
+
+# print(C1)
+# print(C2)
+
+C1.subtract(C2)
+
+diff_norm = C1.norm()
+
+print("")
+print(f"Diff_norm: {diff_norm}")
+print(f"E1: {E1:+6.10f}")
+print(f"E2: {E2:+6.10f}")
+print("")
+print(tmr)
+
+
+

--- a/sandbox/sqop_pool/test_df_pool_v1.py
+++ b/sandbox/sqop_pool/test_df_pool_v1.py
@@ -1,0 +1,108 @@
+import qforte as qf
+import numpy as np
+ 
+import time
+
+# Define the reference and geometry lists.
+geom = [
+    ('H', (0., 0., 1.0)), 
+    ('H', (0., 0., 2.0)),
+    # ('H', (0., 0., 3.0)), 
+    # ('H', (0., 0., 4.0)),
+    # ('H', (0., 0., 5.0)), 
+    # ('H', (0., 0., 6.0)),
+    # ('H', (0., 0., 7.0)), 
+    # ('H', (0., 0., 8.0)),
+    # ('H', (0., 0., 9.0)), 
+    # ('H', (0., 0.,10.0)),
+    # ('H', (0., 0.,11.0)), 
+    # ('H', (0., 0.,12.0))
+    ]
+
+
+# geom = [
+#     ('H', (0., 0., 1.0)), 
+#     ('Be', (0., 0., 2.0)),
+#     ('H', (0., 0., 3.0)), 
+#     ]
+
+# geom = [('Li', [0.0, 0.0, 0.0]), ('H', [0.0, 0.0, 1.45])]
+
+# Get the molecule object that now contains both the fermionic and qubit Hamiltonians.
+mol = qf.system_factory(
+    build_type='psi4', 
+    mol_geometry=geom, 
+    basis='sto-3g', 
+    build_qb_ham = False, 
+    run_fci=1,
+    store_mo_ints=1,
+    build_df_ham=1,  # NOTE(for Victor): Need to do in order build  df_ham
+    df_icut=1.0e-10)
+
+sq_ham = mol.sq_hamiltonian
+ 
+print("\n Initial FCIcomp Stuff")
+print("===========================")
+ref = mol.hf_reference
+
+nel = sum(ref)
+sz = 0
+norb = int(len(ref) / 2)
+
+print(f" nqbit:     {norb*2}")
+print(f" nel:       {nel}")
+ 
+fc1 = qf.FCIComputer(nel=nel, sz=sz, norb=norb)
+fc1.hartree_fock()
+
+fc2 = qf.FCIComputer(nel=nel, sz=sz, norb=norb)
+fc2.hartree_fock()
+
+rand = False
+if(rand):
+    random_array = np.random.rand(fc1.get_state().shape()[0], fc1.get_state().shape()[1])
+    random = np.array(random_array, dtype = np.dtype(np.complex128))
+    Crand = qf.Tensor(fc1.get_state().shape(), "Crand")
+    Crand.fill_from_nparray(random.ravel(), Crand.shape())
+    rand_nrm = Crand.norm()
+    Crand.scale(1/rand_nrm)
+    fc1.set_state(Crand)
+    fc2.set_state(Crand)
+
+dt = 1.0
+
+# NOTE(for Victor): Must scale the first leaf with dt!
+qf.helper.df_ham_helper.time_scale_first_leaf(mol.df_ham, dt)
+v_lst = mol.df_ham.get_scaled_density_density_matrices()
+gt_lst = mol.df_ham.get_trotter_basis_change_matrices()
+g_lst = mol.df_ham.get_basis_change_matrices()
+
+print(f"\nnorb {len(geom)} len v_lst {len(v_lst)} len g_lst {len(g_lst)} en gt_lst {len(gt_lst)}\n")
+sqdf_ham_pool = qf.SQOpPool()
+
+sqdf_ham_pool = qf.SQOpPool()
+sqdf_ham_pool.fill_pool_df_trotter(mol.df_ham, dt)
+
+fc1.apply_sqop(mol.sq_hamiltonian)
+fc2.apply_sqop_pool(sqdf_ham_pool)
+
+E1 = fc1.get_hf_dot()
+E2 = fc2.get_hf_dot()
+
+C1 = fc1.get_state_deep()
+C2 = fc2.get_state_deep()
+
+C1.subtract(C2)
+
+diff_norm = C1.norm()
+
+# print(C1)
+
+print("")
+print(f"Diff_norm: {diff_norm}")
+print(f"E1: {E1:6.10f}")
+print(f"E2: {E2:6.10f}")
+
+# print(sqdf_ham_pool)
+
+# takeaway as of 7/31/2024 is that just applying the SQop does not give back the HF state.

--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -239,6 +239,7 @@ PYBIND11_MODULE(qforte, m) {
         .def(py::init<int, int, int>(), "nel"_a, "sz"_a, "norb"_a, "Make a FCIComputer with nel, sz, and norb")
         .def("hartree_fock", &FCIComputer::hartree_fock)
         .def("set_element", &FCIComputer::set_element)
+        .def("apply_tensor_spat_1bdy", &FCIComputer::apply_tensor_spat_1bdy)
         .def("apply_tensor_spin_1bdy", &FCIComputer::apply_tensor_spin_1bdy)
         .def("apply_tensor_spin_12bdy", &FCIComputer::apply_tensor_spin_12bdy)
         .def("apply_tensor_spin_012bdy", &FCIComputer::apply_tensor_spin_012bdy)
@@ -275,6 +276,7 @@ PYBIND11_MODULE(qforte, m) {
             py::arg("antiherm") = false,
             py::arg("adjoint") = false
             )
+        .def("apply_df_ham", &FCIComputer::apply_df_ham)
         .def("evolve_df_ham_trotter", &FCIComputer::evolve_df_ham_trotter)
         .def("evolve_givens", &FCIComputer::evolve_givens)
         .def("evolve_diagonal_from_mat", &FCIComputer::evolve_diagonal_from_mat)

--- a/src/qforte/df_hamiltonian.cc
+++ b/src/qforte/df_hamiltonian.cc
@@ -177,21 +177,12 @@ std::tuple<
         for (size_t idx = 0; idx < row_indices.size(); ++idx) {
             size_t i = row_indices[idx];
             size_t j = column_indices[idx];
-
-            // size_t ij_right = current_matrix.tidx_to_vidx({i, j});
             size_t ij_right = n*i + j;
 
             std::complex<double> right_element = std::conj(current_matrix.data()[ij_right]);
-            // std::complex<double> right_element = std::conj(current_matrix[i][j]);
-
             if (always_insert || std::abs(right_element) > 1.0e-11) {
-
-                // size_t ij_left = current_matrix.tidx_to_vidx({i, j-1});
                 size_t ij_left = n * i + j - 1;
                 std::complex<double> left_element = std::conj(current_matrix.data()[ij_left]);
-
-                // std::complex<double> left_element = std::conj(current_matrix[i][j - 1]);
-
                 auto givens_rotation = givens_matrix_elements(left_element, right_element, "right");
 
                 double theta = std::asin(std::real(givens_rotation[1][0]));

--- a/src/qforte/fci_computer.h
+++ b/src/qforte/fci_computer.h
@@ -50,9 +50,13 @@ class FCIComputer {
     /// apply a TensorOperator to the current state 
     void apply_tensor_operator(const TensorOperator& top);
 
+    void apply_tensor_spat_1bdy(
+      const Tensor& h1e, 
+      size_t norb);
+
     /// apply a 1-body TensorOperator to the current state 
     // void apply_tensor_spin_1bdy(const TensorOperator& top);
-
+    
     void apply_tensor_spin_1bdy(
       const Tensor& h1e, 
       size_t norb);
@@ -314,6 +318,11 @@ class FCIComputer {
       const Tensor& h2e_einsum, 
       size_t norb);  
 
+    /// Applies the double factorized hamiltonian to the current state
+    void apply_df_ham(
+      const DFHamiltonian& df_ham,
+      const double nuc_rep_en);
+
     /// Applies the trotterized form of a
     /// double factorized hamiltonain time evolution,
     /// NOTE: thresholds for the double factorization eigenvalue cutoffs
@@ -333,6 +342,9 @@ class FCIComputer {
       const Tensor& V,
       const double evolution_time);
 
+    /// Apply a diagonal operator defined by V to the wave funciton.
+    void apply_diagonal_from_mat(const Tensor& V);
+
     void apply_diagonal_array(
       Tensor& C, // Just try in-place for now...
       const std::vector<uint64_t>& astrs,
@@ -343,7 +355,8 @@ class FCIComputer {
       const size_t nbeta_strs,
       const size_t nalfa_el,
       const size_t nbeta_el,
-      const size_t norb);
+      const size_t norb,
+      const bool exponentiate = true);
 
     void apply_diagonal_array_part(
       std::vector<std::complex<double>>& out, 
@@ -432,6 +445,8 @@ class FCIComputer {
     void hartree_fock();
 
     void print_vector(const std::vector<int>& vec, const std::string& name);
+
+    void print_vector_z(const std::vector<std::complex<double>>& vec, const std::string& name);
 
     void print_vector_uint(const std::vector<uint64_t>& vec, const std::string& name);
 


### PR DESCRIPTION
## Description
This PR adds the ability to apply a double factorized hamiltonian to a FCIComputer object. Example code can be found in qforte/sandbox/sqop_pool/test_app_df_ham_v1.py.

## User Notes
- [x] Features added
- [x] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [ ] Ready to go!
