### PR TITLE
Adds k-UpCCGSD ansatz, minor modifications to HVA-VQE.

### DIFF
--- a/sandbox/vqe_fci_comp/test_fci_vqe_hva_v1.py
+++ b/sandbox/vqe_fci_comp/test_fci_vqe_hva_v1.py
@@ -4,8 +4,8 @@ import qforte as qf
 geom = [
     ('H', (0., 0., 1.00)),
     ('H', (0., 0., 2.00)),
-    ('H', (0., 0., 3.00)),
-    ('H', (0., 0., 4.00)),
+    # ('H', (0., 0., 3.00)),
+    # ('H', (0., 0., 4.00)),
     # ('H', (0., 0., 5.00)),
     # ('H', (0., 0., 6.00)),
     # ('H', (0., 0., 7.00)),
@@ -28,6 +28,7 @@ mol = qf.system_factory(
     build_type='psi4', 
     mol_geometry=geom, 
     basis='sto-3g',
+    symmetry='d2h',
     run_fci=1)
 
 timer.record("Psi4 Setup")
@@ -38,6 +39,7 @@ alg = qf.HVAVQE(
     mol,
     computer_type = 'fci',
     apply_ham_as_tensor = True,
+    verbose=True
     )
 
 timer.reset()
@@ -48,12 +50,15 @@ alg.run(
     pool_type='SQHVA',
     optimizer='BFGS',
     use_analytic_grad=True,
-    start_from_ham_params=True,
+    start_from_ham_params=False,
     noise_factor=1.0e-12)
 
 timer.record("HVA FCI")
 
 print(timer)
             
-print(f'\n\n Efci:   {mol.fci_energy:+12.10f}')
+print('\n\n')
+print(f'Efci:        {mol.fci_energy:+12.10f}')
+print(f'Ehva:        {alg.get_gs_energy():+12.10f}')
+print(f'|dE|:        {mol.fci_energy - alg.get_gs_energy():+12.10f}')
 

--- a/sandbox/vqe_fci_comp/test_fci_vqe_kpucc_v1.py
+++ b/sandbox/vqe_fci_comp/test_fci_vqe_kpucc_v1.py
@@ -1,0 +1,91 @@
+import qforte as qf
+
+
+geom = [
+    # ('Be', (0., 0., 1.00)), 
+    ('H', (0., 0., 1.00)),
+    ('H', (0., 0., 2.00)),
+    ('H', (0., 0., 3.00)),
+    ('H', (0., 0., 4.00)),
+    ('H', (0., 0., 5.00)),
+    ('H', (0., 0., 6.00)),
+    # ('H', (0., 0., 7.00)),
+    # ('H', (0., 0., 8.00)),
+    # ('H', (0., 0., 9.00)),
+    # ('H', (0., 0., 10.00))
+    ]
+
+# geom = [
+#     ('Be', (0., 0., 2.00)), 
+#     ('H', (0., 0., 1.00)),
+#     ('H', (0., 0., 3.00)),
+#     ]
+
+# geom = [
+#     ('N', (0., 0., 1.00)),
+#     ('N', (0., 0., 2.00)),
+#     ]
+
+kmax = 3
+
+timer = qf.local_timer()
+
+timer.reset()
+
+mol = qf.system_factory(
+    build_type='psi4', 
+    mol_geometry=geom, 
+    basis='sto-3g',
+    symmetry='d2h',
+    run_fci=1)
+
+timer.record("Psi4 Setup")
+
+
+UCCSD = qf.UCCNVQE(
+    mol,
+    computer_type = 'fci',
+    apply_ham_as_tensor = True
+    )
+
+timer.reset()
+UCCSD.run(opt_thresh=1.0e-4, 
+            pool_type='SD',
+            optimizer='BFGS',
+            )
+
+timer.record("dUCCSD FCI")
+
+print(timer)
+            
+print(f'\n\n Efci:   {mol.fci_energy:+12.10f}')
+
+
+pool_str = f'{kmax}-UpCCGSD'
+
+
+pUCCGSD = qf.UCCNVQE(
+    mol,
+    computer_type = 'fci',
+    apply_ham_as_tensor = True,
+    verbose=False
+    )
+
+timer.reset()
+pUCCGSD.run(opt_thresh=1.0e-4, 
+            pool_type=pool_str,
+            optimizer='BFGS',
+            opt_maxiter=500,
+            use_analytic_grad=True
+            )
+
+timer.record("k FCI")
+
+print(timer)
+
+print('\n\n')
+print(f'Efci:        {mol.fci_energy:+12.10f}')
+print(f'Euccsd:      {UCCSD.get_gs_energy():+12.10f}')
+print(f'|dEuccsd|:   {mol.fci_energy - UCCSD.get_gs_energy():+12.10f}')
+print(f'Ekupcc:      {pUCCGSD.get_gs_energy():+12.10f}')
+print(f'|dEkupcc|:   {mol.fci_energy - pUCCGSD.get_gs_energy():+12.10f}')

--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -328,6 +328,17 @@ class AnsatzAlgorithm(Algorithm):
             self._pool_obj.fill_pool(self._pool_type)
             timer2.record("_pool_obj.fill_pool")
 
+        elif (self._pool_type[0].isdigit() and self._pool_type[1:] == '-UpCCGSD'):
+            self._pool_obj = qf.SQOpPool()
+
+            timer2.reset()
+            self._pool_obj.set_orb_spaces(self._ref)
+            timer2.record("_pool_obj.set_orb_spaces")
+
+            timer2.reset()
+            self._pool_obj.fill_pool_kUpCCGSD(int(self._pool_type[0]))
+            timer2.record("_pool_obj.fill_pool")
+
         elif isinstance(self._pool_type, qf.SQOpPool):
             self._pool_obj = self._pool_type
         else:

--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -136,6 +136,8 @@ PYBIND11_MODULE(qforte, m) {
         .def("get_qubit_operator", &SQOpPool::get_qubit_operator, py::arg("order_type"),
              py::arg("combine_like_terms") = true, py::arg("qubit_excitations") = false)
         .def("fill_pool", &SQOpPool::fill_pool)
+        .def("fill_pool_kUpCCGSD", &SQOpPool::fill_pool_kUpCCGSD)
+        .def("fill_pool_sq_hva", &SQOpPool::fill_pool_sq_hva)
         .def("fill_pool_df_trotter", &SQOpPool::fill_pool_df_trotter)
         .def("append_givens_ops_sector", &SQOpPool::append_givens_ops_sector)
         .def("append_diagonal_ops_all", &SQOpPool::append_diagonal_ops_all)

--- a/src/qforte/sq_op_pool.cc
+++ b/src/qforte/sq_op_pool.cc
@@ -546,6 +546,125 @@ void SQOpPool::fill_pool(std::string pool_type){
     }
 }
 
+void SQOpPool::fill_pool_kUpCCGSD(int kmax)
+{
+    for(int k=0; k < kmax; ++k){
+        size_t norb = nocc_ + nvir_;
+        for(size_t i=0; i<norb; i++){
+            size_t ia = 2*i;
+            size_t ib = 2*i+1;
+            for (size_t a=i; a<norb; a++){
+                size_t aa = 2*a;
+                size_t ab = 2*a+1;
+
+                if( aa != ia ){
+                    SQOperator temp1a;
+                    temp1a.add_term(+1.0, {aa}, {ia});
+                    temp1a.add_term(-1.0, {ia}, {aa});
+                    temp1a.simplify();
+                    if(temp1a.terms().size() > 0){
+                        add_term(1.0, temp1a);
+                    }
+                }
+
+                if( ab != ib ){
+                    SQOperator temp1b;
+                    temp1b.add_term(+1.0, {ab}, {ib});
+                    temp1b.add_term(-1.0, {ib}, {ab});
+                    temp1b.simplify();
+                    if(temp1b.terms().size() > 0){
+                        add_term(1.0, temp1b);
+                    }
+                }
+            }
+        }
+
+        std::vector< std::vector<size_t> > uniqe_2bdy;
+        std::vector< std::vector<size_t> > adjnt_2bdy;
+
+        for(size_t p=0; p<norb; ++p){
+            size_t pa = 2 * p;
+            size_t pb = 2 * p + 1;
+            for(size_t q=0; q<norb; ++q){
+                size_t qa = 2 * q;
+                size_t qb = 2 * q + 1;
+
+                if((pa != qa) && (pb != qb)){
+                    SQOperator temp2abab;
+                    temp2abab.add_term(-1.0, {pa,pb}, {qa,qb});
+                    temp2abab.add_term(+1.0, {qb,qa}, {pb,pa});
+                    temp2abab.simplify();
+                    if(temp2abab.terms().size() > 0){
+                        std::vector<size_t> vtemp {std::get<1>(temp2abab.terms()[0])[0], std::get<1>(temp2abab.terms()[0])[1], std::get<2>(temp2abab.terms()[0])[0], std::get<2>(temp2abab.terms()[0])[1]};
+                        std::vector<size_t> vadjt {std::get<1>(temp2abab.terms()[1])[0], std::get<1>(temp2abab.terms()[1])[1], std::get<2>(temp2abab.terms()[1])[0], std::get<2>(temp2abab.terms()[1])[1]};
+                        if( (std::find(uniqe_2bdy.begin(), uniqe_2bdy.end(), vtemp) == uniqe_2bdy.end()) ){
+                            if( (std::find(adjnt_2bdy.begin(), adjnt_2bdy.end(), vtemp) == adjnt_2bdy.end()) ){
+                                uniqe_2bdy.push_back(vtemp);
+                                adjnt_2bdy.push_back(vadjt);
+                                add_term(1.0, temp2abab);
+                            }
+                        }
+                    }
+                }
+            }
+        }        
+    }
+}
+
+void SQOpPool::fill_pool_sq_hva(std::complex<double> coeff, const SQOperator& sq_op){
+    std::vector<std::pair< std::vector<size_t>, std::vector<size_t>>> h_vec;
+    std::vector<std::pair< std::vector<size_t>, std::vector<size_t>>> hd_vec;
+
+    for (size_t l = 0; l < sq_op.terms().size(); l++){
+        std::pair< std::vector<size_t>, std::vector<size_t>> h;
+        std::pair< std::vector<size_t>, std::vector<size_t>> hd;
+
+        std::complex<double> hl = std::get<0>(sq_op.terms()[l]);
+        h.first  = std::get<1>(sq_op.terms()[l]);
+        h.second = std::get<2>(sq_op.terms()[l]);
+
+        // skip the scalar term.
+        if(h.first.size()==0 and h.second.size()==0){
+            continue;
+        }
+
+        hd.first = h.second;
+        hd.second = h.first;
+
+        std::reverse(hd.first.begin(), hd.first.end());
+        std::reverse(hd.second.begin(), hd.second.end());
+
+        std::sort(h.first.begin(), h.first.end());
+        std::sort(h.second.begin(), h.second.end());
+
+        std::sort(hd.first.begin(), hd.first.end());
+        std::sort(hd.second.begin(), hd.second.end());
+        
+        // Determine if term is in current set of terms or term adjoints
+        // if it isn't found in either then append the vectors
+        if (std::find(h_vec.begin(), h_vec.end(), h) == h_vec.end()){
+            if (std::find(hd_vec.begin(), hd_vec.end(), h) == hd_vec.end()){
+                SQOperator temp;
+                if(h == hd or h.first == h.second){
+                    // (Nick) Need this checked out for sure
+                    temp.add_term(0.5, h.first,  h.second);
+                    temp.add_term(0.5, hd.first, hd.second);
+                } else {
+                    temp.add_term(1.0, h.first,  h.second);
+                    temp.add_term(1.0, hd.first, hd.second);
+                    temp.simplify();
+                }
+
+                terms_.push_back(std::make_pair(coeff, temp));
+
+                h_vec.push_back(h);
+                hd_vec.push_back(hd);
+
+            }
+        } 
+    }
+}
+
 void SQOpPool::fill_pool_df_trotter(
     const DFHamiltonian& df_ham,
     const std::complex<double> coeff)

--- a/src/qforte/sq_op_pool.h
+++ b/src/qforte/sq_op_pool.h
@@ -49,6 +49,16 @@ class SQOpPool {
     /// builds the sq operator pool
     void fill_pool(std::string pool_type);
 
+    /// builds the sq operator pool using kmax repeats of the 
+    /// disentangled unitary paired coupled cluster singleds and
+    /// doubles ansatz.
+    void fill_pool_kUpCCGSD(int kmax);
+
+    /// builds the sq operator pool based on the operators in the 
+    /// second quantized hamiltonain. Similar to add_hermitian pairs
+    /// but intitalizees to zero 
+    void fill_pool_sq_hva(std::complex<double> coeff, const SQOperator& sq_op);
+
     /// builds the sq operator pool that, when trotterized, 
     /// reporduces the (trotterized) evolution uder a
     /// DFHamiltonian. 


### PR DESCRIPTION
## Description
This PR adds the ability to use the k-UpCCGSD ansatz in the UCC-VQE subclass. Currently it builds a pool with kmax repeats of the 1-UpCCGSD, and optimizes all parameters together. It may be beneficial to implement a layer-by-layer optimization in the future as a stable optimization isn't always observed for high kmax. Sandbox test cases can be found in qforte/sandbox/vqe_fci_comp/test_fci_adaptvqe_ducc_v1.py.

This PR also makes minor modifications to the SQ-HVA-VQE class. At present it appears all gradients are zero when ansatz is initialized with all parameters zeroed and a HF reference state is used. Mathematically it seems this should not be the case, but Finite Difference gradients seem to also agree that this is the case. 

## User Notes
- [x] Features added
- [x] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [ ] Ready to go!
