### PR TITLE
Add pyscf builder

### DIFF
--- a/sandbox/pyscf_adapter/test_v1.py
+++ b/sandbox/pyscf_adapter/test_v1.py
@@ -1,0 +1,50 @@
+import qforte as qf
+
+print('\nBuild Geometry')
+print('-------------------------')
+
+symm_str = 'c1'
+
+geom = [('H', (0., 0., 1.00)),
+        ('H', (0., 0., 2.00)), 
+        ('H', (0., 0., 3.00)),
+        ('H', (0., 0., 4.00)),
+        # ('H', (0., 0., 5.00)),
+        # ('H', (0., 0., 3.00)), 
+        ]
+
+### ====> Build Qforte Mol with Psi4 <==== ###
+mol1 = qf.system_factory(
+    build_type='psi4', 
+    symmetry=symm_str,
+    mol_geometry=geom, 
+    basis='sto-6g', 
+    run_fci=True, 
+    run_ccsd=False,
+    store_mo_ints=True,
+    build_df_ham=False,
+    # df_icut=1.0e-1
+    )
+
+
+print(f'The FCI energy from Psi4:         {mol1.fci_energy:12.10f}')
+print(f'The SCF energy from Psi4:         {mol1.hf_energy:12.10f}')
+
+
+
+### ====> Build Qforte Mol with Psi4 <==== ###
+mol2 = qf.system_factory(
+    build_type='pyscf', 
+    symmetry=symm_str,
+    mol_geometry=geom, 
+    basis='sto-6g', 
+    run_fci=True, 
+    run_ccsd=False,
+    store_mo_ints=True,
+    build_df_ham=False,
+    # df_icut=1.0e-1
+    )
+
+
+print(f'The FCI energy from Pyscf:         {mol2.fci_energy:12.10f}')
+print(f'The SCF energy from Pyscf:         {mol2.hf_energy:12.10f}')

--- a/sandbox/pyscf_adapter/test_v2.py
+++ b/sandbox/pyscf_adapter/test_v2.py
@@ -1,0 +1,99 @@
+import qforte as qf
+
+# ====> Goal of Sandbox Test <==== #
+# To test the pyscf integral interface
+
+print('\nBuild Geometry')
+print('-------------------------')
+
+symm_str = 'd2h'
+fdocc = 4
+fuocc = 0
+
+geom = [('H', (0., 0.,  1.00)),
+        ('H', (0., 0.,  2.00)), 
+        ('H', (0., 0.,  3.00)),
+        ('H', (0., 0.,  4.00)),
+        ('H', (0., 0.,  5.00)),
+        ('H', (0., 0.,  6.00)),
+        ('H', (0., 0.,  7.00)),
+        ('H', (0., 0.,  8.00)),  
+        ('H', (0., 0.,  9.00)),
+        ('H', (0., 0., 10.00)),  
+        ]
+
+### ====> Build Qforte Mol with Psi4 <==== ###
+mol1 = qf.system_factory(
+    build_type='psi4', 
+    symmetry=symm_str,
+    mol_geometry=geom, 
+    basis='sto-6g', 
+    run_fci=True, 
+    run_ccsd=False,
+    store_mo_ints=True,
+    build_df_ham=False,
+    num_frozen_uocc = fuocc, # must be..
+    num_frozen_docc = fdocc,
+    )
+
+
+print(f'The FCI energy from Psi4:         {mol1.fci_energy:12.10f}')
+print(f'The SCF energy from Psi4:         {mol1.hf_energy:12.10f}')
+
+
+# Confirm HF works
+alg1 = qf.UCCNPQE(
+    mol1,
+    computer_type = 'fci',
+    apply_ham_as_tensor=True,
+    verbose=False)
+
+
+alg1.run(
+    opt_thresh=1.0e-4, 
+    pool_type='SD',
+    )
+
+
+
+## ====> Build Qforte Mol with Psi4 <==== ###
+mol2 = qf.system_factory(
+    build_type='pyscf', 
+    symmetry=symm_str,
+    mol_geometry=geom, 
+    basis='sto-6g', 
+    run_fci=True, 
+    run_ccsd=False,
+    store_mo_ints=True,
+    build_df_ham=False,
+    num_frozen_uocc = fuocc,
+    num_frozen_docc = fdocc
+    )
+
+
+print(f'The FCI energy from Pyscf:         {mol2.fci_energy:12.10f}')
+print(f'The SCF energy from Pyscf:         {mol2.hf_energy:12.10f}')
+
+alg2 = qf.UCCNPQE(
+    mol2,
+    computer_type = 'fci',
+    apply_ham_as_tensor=True,
+    verbose=False)
+
+
+alg2.run(
+    opt_thresh=1.0e-4, 
+    pool_type='SD',
+    )
+
+
+print(f'The SCF energy from Psi4:         {mol1.hf_energy:12.10f}')
+print(f'The SCF energy from Pyscf:        {mol2.hf_energy:12.10f}')
+print('')
+
+print(f'The FCI energy from Psi4:         {mol1.fci_energy:12.10f}')
+print(f'The PQE energy with Psi4 ints:    {alg1._Egs:12.10f}')
+print('')
+
+print(f'The FCI energy from Pyscf:        {mol2.fci_energy:12.10f}')
+print(f'The PQE energy with Pyscf ints:   {alg2._Egs:12.10f}')

--- a/sandbox/pyscf_adapter/test_v3.py
+++ b/sandbox/pyscf_adapter/test_v3.py
@@ -1,0 +1,103 @@
+import qforte as qf
+
+# ====> Goal of Sandbox Test <==== #
+# To test the pyscf integral interface
+
+print('\nBuild Geometry')
+print('-------------------------')
+
+symm_str = 'c1'
+fdocc = 0
+fuocc = 0
+
+geom = [('H', (0., 0.,  1.00)),
+        ('H', (0., 0.,  2.00)), 
+        ('H', (0., 0.,  3.00)),
+        ('H', (0., 0.,  4.00)),
+        ('H', (0., 0.,  5.00)),
+        ('H', (0., 0.,  6.00)),
+        ('H', (0., 0.,  7.00)),
+        ('H', (0., 0.,  8.00)),  
+        # ('H', (0., 0.,  9.00)),
+        # ('H', (0., 0., 10.00)),  
+        ]
+
+### ====> Build Qforte Mol with Psi4 <==== ###
+# mol1 = qf.system_factory(
+#     build_type='psi4', 
+#     symmetry=symm_str,
+#     mol_geometry=geom, 
+#     basis='sto-6g', 
+#     run_fci=True, 
+#     run_ccsd=False,
+#     store_mo_ints=True,
+#     build_df_ham=False,
+#     num_frozen_uocc = fuocc, # must be..
+#     num_frozen_docc = fdocc,
+#     )
+
+
+# print(f'The FCI energy from Psi4:         {mol1.fci_energy:12.10f}')
+# print(f'The SCF energy from Psi4:         {mol1.hf_energy:12.10f}')
+
+
+# # Confirm HF works
+# alg1 = qf.UCCNPQE(
+#     mol1,
+#     computer_type = 'fci',
+#     apply_ham_as_tensor=True,
+#     verbose=False)
+
+
+# alg1.run(
+#     opt_thresh=1.0e-4, 
+#     pool_type='SD',
+#     )
+
+
+
+## ====> Build Qforte Mol with PySCF (using AVAS) <==== ###
+mol2 = qf.system_factory(
+    build_type='pyscf', 
+    symmetry=symm_str,
+    mol_geometry=geom, 
+    basis='cc-pvdz', 
+    run_fci=True, 
+    use_avas=True, #                     <=====
+    avas_atoms_or_orbitals=['H 1s'],
+    run_ccsd=False,
+    store_mo_ints=True,
+    build_df_ham=False,
+    num_frozen_uocc = fuocc,
+    num_frozen_docc = fdocc,
+    build_qb_ham = False,
+    )
+
+
+print(f'The FCI energy from Pyscf:         {mol2.fci_energy:12.10f}')
+print(f'The SCF energy from Pyscf:         {mol2.hf_energy:12.10f}')
+
+alg2 = qf.UCCNPQE(
+    mol2,
+    computer_type = 'fci',
+    apply_ham_as_tensor=True, #          <=====
+    verbose=False)
+
+
+alg2.run(
+    opt_thresh=1.0e-4, 
+    pool_type='SD',
+    )
+
+
+# print(f'The SCF energy from Psi4:         {mol1.hf_energy:12.10f}')
+# print(f'The SCF energy from Pyscf:        {mol2.hf_energy:12.10f}')
+# print('')
+
+# print(f'The FCI energy from Psi4:         {mol1.fci_energy:12.10f}')
+# print(f'The PQE energy with Psi4 ints:    {alg1._Egs:12.10f}')
+# print('')
+
+print(f'The FCI energy from Pyscf:        {mol2.fci_energy:12.10f}')
+print(f'The PQE energy with Pyscf ints:   {alg2._Egs:12.10f}')
+

--- a/sandbox/pyscf_adapter/test_v4.py
+++ b/sandbox/pyscf_adapter/test_v4.py
@@ -1,0 +1,128 @@
+import qforte as qf
+
+# ====> Goal of Sandbox Test <==== #
+# To test the pyscf integral interface
+
+print('\nBuild Geometry')
+print('-------------------------')
+
+symm_str = 'c1'
+fdocc = 0
+fuocc = 0
+
+basis_set = 'cc-pvdz'
+avas_atoms_and_atomic_orbs = ['C 2pz']
+
+# 8-ene geom
+geom = [
+('C', ( 0.335863334534,    -0.638024393629,    -0.000000000000)),
+('H', ( 1.432938652990,    -0.620850836653,    -0.000000000000)),
+('C', (-0.296842857597,    -1.839541058429,     0.000000000000)),
+('H', (-1.393739535698,    -1.860704460450,     0.000000000000)),
+('C', ( 0.383204712221,    -3.118962195977,     0.000000000000)),
+('H', ( 1.479554414548,    -3.087255036285,     0.000000000000)),
+('C', (-0.237579216697,    -4.313790116847,     0.000000000000)),
+('H', ( 0.325161369217,    -5.249189992705,     0.000000000000)),
+('H', (-1.329245260575,    -4.386987278270,     0.000000000000)),
+('C', (-0.335863334534,     0.638024393629,     0.000000000000)),
+('H', (-1.432938652990,     0.620850836653,     0.000000000000)),
+('C', ( 0.296842857597,     1.839541058429,     0.000000000000)),
+('H', ( 1.393739535698,     1.860704460450,     0.000000000000)),
+('C', (-0.383204712221,     3.118962195977,     0.000000000000)),
+('H', (-1.479554414548,     3.087255036285,     0.000000000000)),
+('C', ( 0.237579216697,     4.313790116847,     0.000000000000)),
+('H', ( 1.329245260575,     4.386987278270,     0.000000000000)),
+('H', (-0.325161369217,     5.249189992705,     0.000000000000)),
+        ]
+
+# 12-ene geom
+# C            0.318934151643     1.838664211757     0.000000000000
+# H            1.415980959638     1.843665440633     0.000000000000
+# C           -0.328238108423     0.638465784864     0.000000000000
+# H           -1.425382504623     0.634328966959     0.000000000000
+# C            0.328238108423    -0.638465784864     0.000000000000
+# H            1.425382504623    -0.634328966959     0.000000000000
+# C           -0.318934151643    -1.838664211757     0.000000000000
+# H           -1.415980959638    -1.843665440633     0.000000000000
+# C           -0.339993000522     3.116591194820     0.000000000000
+# H           -1.437280937131     3.109148808007     0.000000000000
+# C            0.302193183930     4.315542102589     0.000000000000
+# H            1.399191891261     4.328262148643     0.000000000000
+# C           -0.368438664361     5.598270030604     0.000000000000
+# H           -1.465038377840     5.574093341283     0.000000000000
+# C            0.259998191265     6.789887178283     0.000000000000
+# H            1.352081696730     6.856305536198     0.000000000000
+# C            0.339993000522    -3.116591194820     0.000000000000
+# H            1.437280937131    -3.109148808007     0.000000000000
+# C           -0.302193183930    -4.315542102589     0.000000000000
+# H           -1.399191891261    -4.328262148643     0.000000000000
+# C            0.368438664361    -5.598270030604     0.000000000000
+# H            1.465038377840    -5.574093341283     0.000000000000
+# C           -0.259998191265    -6.789887178283     0.000000000000
+# H           -1.352081696730    -6.856305536198     0.000000000000
+# H            0.297077214646    -7.728635113123     0.000000000000
+# H           -0.297077214646     7.728635113123     0.000000000000
+
+
+## ====> Build Qforte Mol with PySCF (using AVAS) <==== ###
+mol = qf.system_factory(
+    build_type='pyscf', 
+    symmetry=symm_str,
+    mol_geometry=geom, 
+    basis=basis_set, 
+    run_fci=True, 
+    use_avas=True, #                     <=====
+    avas_atoms_or_orbitals=avas_atoms_and_atomic_orbs,
+    run_ccsd=False,
+    store_mo_ints=True,
+    build_df_ham=False,
+    num_frozen_uocc = fuocc,
+    num_frozen_docc = fdocc,
+    build_qb_ham = False,
+    )
+
+
+print(f'The FCI energy from Pyscf:         {mol.fci_energy:12.10f}')
+print(f'The SCF energy from Pyscf:         {mol.hf_energy:12.10f}')
+
+# alg1 = qf.UCCNPQE(
+#     mol,
+#     computer_type = 'fci',
+#     apply_ham_as_tensor=True,  #          <=====
+#     verbose=False)
+
+# alg1.run(
+#     opt_thresh=1.0e-4, 
+#     pool_type='SD',
+#     )
+
+alg2 = qf.QITE(
+    mol, 
+    reference=mol.hf_reference, 
+    computer_type='fci', 
+    verbose=0, 
+    print_summary_file=0,
+    apply_ham_as_tensor=True)
+
+alg2.run(
+    beta=10.0, 
+    db=1.0,
+    dt=0.001,                     # <===== Time evo for selection process
+    use_exact_evolution=False,    # <===== Exact Evo
+    do_lanczos=False,              # <===== Lanczos (broken at the moment?)
+    sparseSb=False,
+    expansion_type='SD',         # <===== Pool Type
+    low_memorySb=False,
+    second_order=True, 
+    print_pool=False, 
+    evolve_dfham=False, 
+    random_state=False, 
+    selected_pool=False,           # <===== Selcct Pool?
+    physical_r=True,              # <===== Not sure about this? (realistic selection?)
+    cumulative_t=True,
+    t_thresh=1.0e-2)
+
+print(f'The FCI energy from Pyscf:        {mol.fci_energy:12.10f}')
+# print(f'The PQE energy with Pyscf ints:   {alg1._Egs:12.10f}')
+print(f'The QITE energy with Pyscf ints:  {alg2._Egs:12.10f}')
+

--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -135,11 +135,21 @@ class Algorithm(ABC):
         self._qb_ham = system.hamiltonian
         self._sq_ham = system.sq_hamiltonian
 
+        self._zero_body_energy = 0.0
+
         if(hasattr(system, 'nuclear_repulsion_energy')):
             self._nuclear_repulsion_energy = system.nuclear_repulsion_energy
+            self._zero_body_energy += system.nuclear_repulsion_energy
         else:
             print("NOTE: No nuclear repulsion enerly set! Using only provided Hamiltonain.")
             self._nuclear_repulsion_energy = 0.0
+
+        if(hasattr(system, 'frozen_core_energy')):
+            self._frozen_core_energy = system.frozen_core_energy
+            self._zero_body_energy += system.frozen_core_energy
+        else:
+            print("NOTE: No frozen core energy repulsion enerly set! Using only provided Hamiltonain.")
+            self._frozen_core_energy= 0.0
 
         if(computer_type=='fci'):
             if(apply_ham_as_tensor):
@@ -148,7 +158,7 @@ class Algorithm(ABC):
                 self._mo_teis_einsum = system.mo_teis_einsum
                 
 
-        if self._qb_ham.num_qubits() != self._nqb:
+        if len(self._qb_ham.terms()) > 0 and self._qb_ham.num_qubits() != self._nqb:
             raise ValueError(f"The reference has {self._nqb} qubits, but the Hamiltonian has {self._qb_ham.num_qubits()}. This is inconsistent.")
         try:
             self._hf_energy = system.hf_energy
@@ -495,7 +505,7 @@ class AnsatzAlgorithm(Algorithm):
             
             self._curr_energy = np.real(
                 qc.get_exp_val_tensor(
-                    self._nuclear_repulsion_energy, 
+                    self._zero_body_energy, 
                     self._mo_oeis, 
                     self._mo_teis, 
                     self._mo_teis_einsum, 

--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -270,7 +270,7 @@ class UCCVQE(VQE, UCC):
 
         if(self._apply_ham_as_tensor):
             qc_sig.apply_tensor_spat_012bdy(
-                self._nuclear_repulsion_energy, 
+                self._zero_body_energy, 
                 self._mo_oeis, 
                 self._mo_teis, 
                 self._mo_teis_einsum, 
@@ -427,7 +427,7 @@ class UCCVQE(VQE, UCC):
         # qc_sig.apply_operator(self._qb_ham)
         if(self._apply_ham_as_tensor):
             qc_sig.apply_tensor_spat_012bdy(
-            self._nuclear_repulsion_energy, 
+            self._zero_body_energy_energy, 
             self._mo_oeis, 
             self._mo_teis, 
             self._mo_teis_einsum, 

--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -26,7 +26,8 @@ except:
 
 try:
     import pyscf
-    from pyscf import gto, scf, mp, fci, ao2mo, symm
+    from pyscf import gto, scf, mp, fci, ao2mo, symm, mcscf
+    from pyscf.mcscf import avas
     use_pyscf = True
 except:
     use_pyscf = False
@@ -167,7 +168,8 @@ def create_psi_mol(**kwargs):
             for j in range(frozen_core):
                 frozen_core_energy += 2 * mo_teis[i, i, j, j] - mo_teis[i, j, j, i]
 
-        # Incorporate in the one-electron integrals the two-electron integrals involving both frozen and non-frozen orbitals.
+        # Incorporate in the one-electron integrals the two-electron integrals 
+        # involving both frozen and non-frozen orbitals.
         # This also ensures that the correct orbital energies will be obtained.
 
         for p in range(frozen_core, nmo - frozen_virtual):
@@ -181,6 +183,8 @@ def create_psi_mol(**kwargs):
     # Build second quantized Hamiltonian
     Hsq = qforte.SQOperator()
     Hsq.add(p4_Enuc_ref + frozen_core_energy, [], [])
+
+    # Note index is over active space orbitals if frozen occ or unocc
     for i in range(frozen_core, nmo - frozen_virtual):
         ia = (i - frozen_core)*2
         ib = (i - frozen_core)*2 + 1
@@ -217,7 +221,7 @@ def create_psi_mol(**kwargs):
         qforte_mol.hamiltonian = Hsq.jw_transform()
     else:
         Hsq.simplify()
-        qforte_mol.hamiltonian = None
+        qforte_mol.hamiltonian = qforte.QubitOperator()
 
     qforte_mol.point_group = [point_group, irreps]
     qforte_mol.orb_irreps = orb_irreps
@@ -235,6 +239,14 @@ def create_psi_mol(**kwargs):
             p4_mo_teis = copy.deepcopy(mo_teis)
 
     if kwargs['store_mo_ints']:
+
+        # Resize mo_oeis and mo_teis if there are frozen orbitals...
+        if(frozen_core or frozen_virtual):
+            # raise ValueError("This doesn't work..")
+            start = frozen_core
+            end = nmo - frozen_virtual
+            mo_oeis = copy.deepcopy(mo_oeis[start:end, start:end])
+            mo_teis = copy.deepcopy(mo_teis[start:end, start:end, start:end, start:end])
 
         # keep ordering consistant with openfermion eri tensors
         mo_teis = np.asarray(mo_teis.transpose(0, 2, 3, 1), order='C')
@@ -489,7 +501,7 @@ def create_pyscf_mol(**kwargs):
     pyscf_geom_str = ""
 
     for geom_line in mol_geometry:
-        pyscf_geom_str += f"\n{geom_line[0]}  {geom_line[1][0]}  {geom_line[1][1]}  {geom_line[1][2]}"
+        pyscf_geom_str += f"\n{geom_line[0]}  {geom_line[1][0]:+12.12f}  {geom_line[1][1]:+12.12f}  {geom_line[1][2]:+12.12f}"
 
     print(' ==> PySCF geometry <==')
     print('-------------------------')
@@ -517,17 +529,26 @@ def create_pyscf_mol(**kwargs):
     mf = scf.RHF(pyscf_mol)
 
     # Set convergence options
-    mf.conv_tol = 1e-8          # Energy convergence criterion
-    mf.conv_tol_grad = 1e-8     # Density convergence criterion
+    mf.conv_tol = 1e-8          
+    mf.conv_tol_grad = 1e-8     
 
     # Perform the SCF calculation
     pyscf_Escf = mf.kernel()
-    # pyscf_wfn = mf  # Wavefunction object analogous to Psi4's wfn
+
+    num_frozen_docc = kwargs.get('num_frozen_docc', 0)
+    num_frozen_uocc = kwargs.get('num_frozen_uocc', 0)
+
+    if (kwargs.get('use_avas', False)):
+        if(num_frozen_docc != 0 or num_frozen_uocc != 0):
+            raise ValueError(f"Presently can't use avas and freeze orbitals simultaniously.")
+        if not kwargs.get('run_fci', False):
+            raise ValueError(f"Presently must run casci to use avas.")
+        if kwargs.get('symmetry', 'c1') != 'c1':
+            raise ValueError(f"Presently use c1 symmetry with avas.")
 
     # Perform additional computations if requested
     if kwargs.get('run_mp2', False):
-        num_frozen_docc = kwargs.get('num_frozen_docc', 0)
-        num_frozen_uocc = kwargs.get('num_frozen_uocc', 0)
+        
         nmo = mf.mo_coeff.shape[1]
         nocc = mol.nelectron // 2
 
@@ -549,129 +570,265 @@ def create_pyscf_mol(**kwargs):
         qforte_mol.mp2_energy = mp2_energy
 
     if kwargs.get('run_fci', False):
-        if kwargs.get('num_frozen_uocc', 0) == 0:
+        if(num_frozen_docc or num_frozen_uocc):
+            # Total number of orbitals
+            nmo = mf.mo_coeff.shape[1]
+
+            # Total number of electrons
+            nelec = mf.mol.nelectron
+
+            # Number of active orbitals
+            ncas = nmo - num_frozen_docc - num_frozen_uocc
+
+            # Number of active electrons (assuming a closed-shell system)
+            nelecas = nelec - 2 * num_frozen_docc
+
+            if nelecas < 0 or ncas <= 0:
+                raise ValueError("Invalid number of frozen orbitals .")
+
+            # Initialize the CASCI object
+            casci = mcscf.CASCI(mf, ncas, nelecas)
+
+            # Freeze the core orbitals
+            casci.frozen = num_frozen_docc  
+
+            # Run the CASCI calculation
+            casci_output = casci.kernel()
+
+            # Store the FCI energy
+            qforte_mol.fci_energy = casci_output[0]
+
+        elif (kwargs.get('use_avas', False)):
+            # **Second Conditional**: Run CASCI using AVAS to select active space
+            # Define the list of atoms or atomic orbitals to include in the active space
+            avas_atoms_or_orbitals = kwargs.get('avas_atoms_or_orbitals', [])
+            avas_threshold = kwargs.get('avas_threshold', 0.2)  # Default threshold
+
+            if not avas_atoms_or_orbitals:
+                raise ValueError("AVAS is enabled, but no atoms or orbitals are specified for the active space.")
+
+            # Run AVAS to obtain the active space
+            avas_obj = avas.AVAS(mf, avas_atoms_or_orbitals, avas_threshold)
+
+            avas_obj.kernel()
+
+            # Number of active orbitals
+            ncas = avas_obj.ncas  
+
+            # Number of active electrons
+            nelecas = avas_obj.nelecas  
+
+            # Reordered MO coefficients with AVAS active space
+            C_avas = avas_obj.mo_coeff  
+            nmo = C_avas.shape[0]
+
+            if nelecas is None:
+                raise ValueError("AVAS couldn't find any active space electrons with avas_atoms_or_orbitals provided")
+
+            F = mf.get_fock()
+
+            # Transform the Fock matrix into the AVAS MO basis
+            F_avas = C_avas.T @ F @ C_avas
+
+            # Get number of core orbitals
+            ncore = nmo - ncas
+
+            # Extract just the active block of the Fock matrix
+            F_active = F_avas[ncore:ncore+ncas, ncore:ncore+ncas]
+
+            # Diagonalize the active-space Fock submatrix
+            mo_energy_active, _ = np.linalg.eigh(F_active)
+            
+            print('\n\n')
+            print("------------------------------------")
+            print("       ==> AVAS Settings <=== ")
+            print("------------------------------------")
+            print(f"  Basis set:               {kwargs['basis']}")
+            print(f"  n electrons:             {mol.nelectron}")
+            print(f"  n molecular orbs:        {nmo}")
+            print(f"  AVAS atoms and orbs:     {avas_atoms_or_orbitals}")
+            print(f"  ncas electrons:          {nelecas}")
+            print(f"  ncas orbitals:           {ncas}")
+            print('\n\n')
+            
+            # Set up CASCI with the AVAS active space
+            casci = mcscf.CASCI(mf, ncas, nelecas)
+            casci.mo_coeff = C_avas
+
+            # Run the CASCI calculation
+            result = casci.kernel()
+
+            #NOTE(Nick): result stores five elements, including the FCI vector
+            casci_total_energy = result[0]
+
+            # Store the CASCI total energy
+            qforte_mol.fci_energy = casci_total_energy
+
+            # ==> Obtain the one- and two-electron integrals in the active space <==
+
+            # Get the effective one-electron integrals in the active space, including core contributions
+            h1eff, ecore = casci.get_h1eff()
+
+            frozen_core_energy = ecore - mol.energy_nuc()
+
+            # Get the active MO coefficients
+            ncore = casci.ncore  # Number of core orbitals (integer)
+            C_cas = casci.mo_coeff[:, ncore:ncore + ncas]
+
+            # Transform the AO integrals to the active MO basis
+            eri_cas = ao2mo.kernel(mf.mol, C_cas, compact=False)
+            eri_cas = eri_cas.reshape(ncas, ncas, ncas, ncas)
+
+            mo_oeis = h1eff
+            mo_teis = eri_cas
+
+        else:
             cisolver = fci.FCI(mf)
             fci_energy, _ = cisolver.kernel()
             qforte_mol.fci_energy = fci_energy
-        else:
-            print('\nWARNING: Skipping FCI computation due to frozen virtual orbitals not being supported in PySCF FCI.\n')
 
-    # Get the MO coefficients
-    C = mf.mo_coeff
-
-    # Get the scalar variables (nuclear repulsion energy)
-    pyscf_Enuc_ref = mol.energy_nuc()
-
-    # Get one-electron integrals and transform to MO basis
-    h_core = mf.get_hcore()
-    mo_oeis = C.T @ h_core @ C  # Transformed one-electron integrals
-
-    # Get two-electron integrals and transform to MO basis
-    nmo = C.shape[1]
-    # AO to MO transformation of two-electron integrals
-    mo_teis = ao2mo.kernel(mol, C, compact=False).reshape(nmo, nmo, nmo, nmo)
-
-    # Get the number of alpha and beta electrons
-    nalpha, nbeta = mol.nelec
-    nel = nalpha + nbeta
-
-    # ===> Run PySCF End <=== #
-
-    # ===> Get more PySCF info <=== #
 
     # Retrieve the number of frozen core and virtual orbitals
+    pyscf_Enuc_ref = mol.energy_nuc()
     frozen_core = kwargs.get('num_frozen_docc', 0)
     frozen_virtual = kwargs.get('num_frozen_uocc', 0)
 
-    # Get symmetry information
-    point_group = mol.groupname.lower()
-    S = mol.intor('int1e_ovlp')
-    irreps_pyscf = symm.label_orb_symm(mol, mol.irrep_name, mol.symm_orb, C, S)
-    irreps_qforte = qforte.irreps_of_point_groups(point_group)
-    irrep_to_index = {irrep : idx for idx, irrep in enumerate(irreps_qforte)}
+    if kwargs.get('use_avas', False):
 
-    # Build the list of orbitals with their energies and irrep indices
-    orbitals = []
-    for i in range(len(mf.mo_energy)):
-        orbital_energy = mf.mo_energy[i]
-        irrep_name = irreps_pyscf[i]
-        irrep_idx = irrep_to_index[irrep_name]
-        orbitals.append([orbital_energy, irrep_idx])
+        # Get symmetry information, should only be c1 if using avas
+        point_group = mol.groupname.lower()
+        S = mol.intor('int1e_ovlp')
+        irreps_pyscf = symm.label_orb_symm(mol, mol.irrep_name, mol.symm_orb, C_cas, S)
+        irreps_qforte = qforte.irreps_of_point_groups(point_group)
+        irrep_to_index = {irrep : idx for idx, irrep in enumerate(irreps_qforte)}
 
-    # Sort orbitals by energy
-    orbitals.sort()
+        # Build the list of orbitals with their energies and irrep indices
+        # print(f"Pyscf irreps   {irreps_pyscf}")
+        # print(f"mo_energy_avas {mo_energy_active}")
 
-    # Extract orbital energies and irrep indices
-    hf_orbital_energies = []
-    orb_irreps_to_int = []
-    for row in orbitals:
-        hf_orbital_energies.append(row[0])
-        orb_irreps_to_int.append(row[1])
+        orbitals = []
+        for i in range(len(mo_energy_active)):
+            orbital_energy = mo_energy_active[i]
+            irrep_name = irreps_pyscf[i]
+            irrep_idx = irrep_to_index[irrep_name]
+            orbitals.append([orbital_energy, irrep_idx])
 
-    # print('\n\n')
-    # print(f"Pyscf orbitals {orbitals}")
-    # print(f"Pyscf point_group {point_group}")
-    # print(f"Pyscf orb_irreps_to_int {orb_irreps_to_int}")
-    # print(f"Pyscf irreps {irreps_qforte}")
-    # print('\n\n')
+        # Don't sort with avas
+        # orbitals.sort()
 
-    orb_irreps = [irreps_qforte[i] for i in orb_irreps_to_int]
+        # Extract orbital energies and irrep indices
+        hf_orbital_energies = []
+        orb_irreps_to_int = []
+        for row in orbitals:
+            hf_orbital_energies.append(row[0])
+            orb_irreps_to_int.append(row[1])
+
+        orb_irreps = [irreps_qforte[i] for i in orb_irreps_to_int]
 
 
-    # Compute the frozen core energy
-    frozen_core_energy = 0.0
+    else:
+        # Get the MO coefficients
+        C = mf.mo_coeff
 
-    if frozen_core > 0:
-        # Sum over frozen core orbitals
-        for i in range(frozen_core):
-            frozen_core_energy += 2 * mo_oeis[i, i]
+        # Get the scalar variables (nuclear repulsion energy)
+        pyscf_Enuc_ref = mol.energy_nuc()
 
-        for i in range(frozen_core):
-            for j in range(frozen_core):
-                frozen_core_energy += 2 * mo_teis[i, i, j, j] - mo_teis[i, j, j, i]
+        # Get one-electron integrals and transform to MO basis
+        h_core = mf.get_hcore()
+        mo_oeis = C.T @ h_core @ C  # Transformed one-electron integrals
 
-        # Adjust the one-electron integrals to account for frozen core orbitals
-        for p in range(frozen_core, nmo - frozen_virtual):
-            for q in range(frozen_core, nmo - frozen_virtual):
-                for i in range(frozen_core):
-                    mo_oeis[p, q] += 2 * mo_teis[p, q, i, i] - mo_teis[p, i, i, q]
+        # Get two-electron integrals and transform to MO basis
+        nmo = C.shape[1]
+        # AO to MO transformation of two-electron integrals
+        mo_teis = ao2mo.kernel(mol, C, compact=False).reshape(nmo, nmo, nmo, nmo)
 
-    # Build the Hartree-Fock reference configuration
-    num_active_orbitals = nmo - frozen_core - frozen_virtual
-    num_active_electrons = nel - 2 * frozen_core
+        # Get the number of alpha and beta electrons
+        nalpha, nbeta = mol.nelec
+        nel = nalpha + nbeta
+
+        # Retrieve the number of frozen core and virtual orbitals
+        frozen_core = kwargs.get('num_frozen_docc', 0)
+        frozen_virtual = kwargs.get('num_frozen_uocc', 0)
+
+        # Get symmetry information
+        point_group = mol.groupname.lower()
+        S = mol.intor('int1e_ovlp')
+        irreps_pyscf = symm.label_orb_symm(mol, mol.irrep_name, mol.symm_orb, C, S)
+        irreps_qforte = qforte.irreps_of_point_groups(point_group)
+        irrep_to_index = {irrep : idx for idx, irrep in enumerate(irreps_qforte)}
+
+        # Build the list of orbitals with their energies and irrep indices
+        orbitals = []
+        for i in range(len(mf.mo_energy)):
+            orbital_energy = mf.mo_energy[i]
+            irrep_name = irreps_pyscf[i]
+            irrep_idx = irrep_to_index[irrep_name]
+            orbitals.append([orbital_energy, irrep_idx])
+
+        # Sort orbitals by energy
+        orbitals.sort()
+
+        # Extract orbital energies and irrep indices
+        hf_orbital_energies = []
+        orb_irreps_to_int = []
+        for row in orbitals:
+            hf_orbital_energies.append(row[0])
+            orb_irreps_to_int.append(row[1])
+
+        # print('\n\n')
+        # print(f"Pyscf orbitals {orbitals}")
+        # print(f"Pyscf point_group {point_group}")
+        # print(f"Pyscf orb_irreps_to_int {orb_irreps_to_int}")
+        # print(f"Pyscf irreps {irreps_qforte}")
+        # print('\n\n')
+
+        orb_irreps = [irreps_qforte[i] for i in orb_irreps_to_int]
+
+    # need a conditioanl for using avas
+    if (kwargs.get('use_avas', False)):
+        num_active_orbitals = ncas
+        num_active_electrons = nelecas
+        Hsq = build_sq_hamiltonian(
+            pyscf_Enuc_ref + frozen_core_energy, 
+            mo_oeis, 
+            mo_teis,
+            ncas,
+            0,
+            0
+            )
+    else:
+        num_active_orbitals = nmo - frozen_core - frozen_virtual
+        num_active_electrons = nel - 2 * frozen_core
+
+        # Compute the frozen core energy
+        frozen_core_energy = 0.0
+        if frozen_core > 0:
+            
+            # Sum over frozen core orbitals
+            for i in range(frozen_core):
+                frozen_core_energy += 2 * mo_oeis[i, i]
+
+            for i in range(frozen_core):
+                for j in range(frozen_core):
+                    frozen_core_energy += 2 * mo_teis[i, i, j, j] - mo_teis[i, j, j, i]
+
+            # Adjust the one-electron integrals to account for frozen core orbitals
+            for p in range(frozen_core, nmo - frozen_virtual):
+                for q in range(frozen_core, nmo - frozen_virtual):
+                    for i in range(frozen_core):
+                        mo_oeis[p, q] += 2 * mo_teis[p, q, i, i] - mo_teis[p, i, i, q]
+
+        Hsq = build_sq_hamiltonian(
+            pyscf_Enuc_ref + frozen_core_energy, 
+            mo_oeis, 
+            mo_teis,
+            nmo,
+            frozen_core,
+            frozen_virtual
+            )
+        
+
     hf_reference = [1] * num_active_electrons + [0] * (2 * num_active_orbitals - num_active_electrons)
-
-    # Build second quantized Hamiltonian
-    Hsq = qforte.SQOperator()
-    Hsq.add(pyscf_Enuc_ref + frozen_core_energy, [], [])
-    for i in range(frozen_core, nmo - frozen_virtual):
-        ia = (i - frozen_core)*2
-        ib = (i - frozen_core)*2 + 1
-        for j in range(frozen_core, nmo - frozen_virtual):
-            ja = (j - frozen_core)*2
-            jb = (j - frozen_core)*2 + 1
-
-            Hsq.add(mo_oeis[i,j], [ia], [ja])
-            Hsq.add(mo_oeis[i,j], [ib], [jb])
-
-            for k in range(frozen_core, nmo - frozen_virtual):
-                ka = (k - frozen_core)*2
-                kb = (k - frozen_core)*2 + 1
-                for l in range(frozen_core, nmo - frozen_virtual):
-                    la = (l - frozen_core)*2
-                    lb = (l - frozen_core)*2 + 1
-
-                    if(ia!=jb and kb != la):
-                        Hsq.add( mo_teis[i,l,k,j]/2, [ia, jb], [kb, la] ) # abba
-                    if(ib!=ja and ka!=lb):
-                        Hsq.add( mo_teis[i,l,k,j]/2, [ib, ja], [ka, lb] ) # baab
-
-                    if(ia!=ja and ka!=la):
-                        Hsq.add( mo_teis[i,l,k,j]/2, [ia, ja], [ka, la] ) # aaaa
-                    if(ib!=jb and kb!=lb):
-                        Hsq.add( mo_teis[i,l,k,j]/2, [ib, jb], [kb, lb] ) # bbbb
-
-    # ===> Get More PySCF Attributes END <=== #
 
     # Set attributes
     qforte_mol.nuclear_repulsion_energy = pyscf_Enuc_ref
@@ -682,7 +839,8 @@ def create_pyscf_mol(**kwargs):
         qforte_mol.hamiltonian = Hsq.jw_transform()
     else:
         Hsq.simplify()
-        qforte_mol.hamiltonian = None
+        # qforte_mol.hamiltonian = None
+        qforte_mol.hamiltonian = qforte.QubitOperator()
 
     qforte_mol.point_group = [point_group, irreps_qforte]
     qforte_mol.orb_irreps = orb_irreps
@@ -700,6 +858,13 @@ def create_pyscf_mol(**kwargs):
             pyscf_mo_teis = copy.deepcopy(mo_teis)
 
     if kwargs['store_mo_ints']:
+        # Resize mo_oeis and mo_teis if there are frozen orbitals...
+        if(frozen_core or frozen_virtual):
+            # raise ValueError("This doesn't work..")
+            start = frozen_core
+            end = nmo - frozen_virtual
+            mo_oeis = copy.deepcopy(mo_oeis[start:end, start:end])
+            mo_teis = copy.deepcopy(mo_teis[start:end, start:end, start:end, start:end])
 
         # keep ordering consistant with openfermion eri tensors
         mo_teis = np.asarray(mo_teis.transpose(0, 2, 3, 1), order='C')
@@ -904,3 +1069,44 @@ def create_external_mol(**kwargs):
     qforte_mol.hamiltonian = qforte_sq_hamiltonian.jw_transform()
 
     return qforte_mol
+
+def build_sq_hamiltonian(
+        zero_body_energy, 
+        mo_oeis, 
+        mo_teis,
+        nmo,
+        frozen_core,
+        frozen_virtual
+        ):
+    
+    # Build second quantized Hamiltonian
+    Hsq = qforte.SQOperator()
+    Hsq.add(zero_body_energy, [], [])
+    for i in range(frozen_core, nmo - frozen_virtual):
+        ia = (i - frozen_core)*2
+        ib = (i - frozen_core)*2 + 1
+        for j in range(frozen_core, nmo - frozen_virtual):
+            ja = (j - frozen_core)*2
+            jb = (j - frozen_core)*2 + 1
+
+            Hsq.add(mo_oeis[i,j], [ia], [ja])
+            Hsq.add(mo_oeis[i,j], [ib], [jb])
+
+            for k in range(frozen_core, nmo - frozen_virtual):
+                ka = (k - frozen_core)*2
+                kb = (k - frozen_core)*2 + 1
+                for l in range(frozen_core, nmo - frozen_virtual):
+                    la = (l - frozen_core)*2
+                    lb = (l - frozen_core)*2 + 1
+
+                    if(ia!=jb and kb != la):
+                        Hsq.add( mo_teis[i,l,k,j]/2, [ia, jb], [kb, la] ) # abba
+                    if(ib!=ja and ka!=lb):
+                        Hsq.add( mo_teis[i,l,k,j]/2, [ib, ja], [ka, lb] ) # baab
+
+                    if(ia!=ja and ka!=la):
+                        Hsq.add( mo_teis[i,l,k,j]/2, [ia, ja], [ka, la] ) # aaaa
+                    if(ib!=jb and kb!=lb):
+                        Hsq.add( mo_teis[i,l,k,j]/2, [ib, jb], [kb, lb] ) # bbbb
+
+    return Hsq

--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -24,6 +24,13 @@ try:
 except:
     use_psi4 = False
 
+try:
+    import pyscf
+    from pyscf import gto, scf, mp, fci, ao2mo, symm
+    use_pyscf = True
+except:
+    use_pyscf = False
+
 
 def create_psi_mol(**kwargs):
     """Builds a qforte Molecule object directly from a psi4 calculation.
@@ -142,7 +149,6 @@ def create_psi_mol(**kwargs):
     for row in orbitals:
         hf_orbital_energies.append(row[0])
         orb_irreps_to_int.append(row[1])
-    del orbitals
 
     point_group = p4_mol.symmetry_from_input().lower()
     irreps = qforte.irreps_of_point_groups(point_group)
@@ -437,6 +443,420 @@ def create_psi_mol(**kwargs):
 
     # Order Psi4 to delete its temporary files.
     psi4.core.clean()
+
+    return qforte_mol
+
+def create_pyscf_mol(**kwargs):
+    """Builds a qforte Molecule object directly from a pyscf calculation.
+
+    Returns
+    -------
+    Molecule
+        The qforte Molecule object which holds the molecular information.
+    """
+
+    kwargs.setdefault('symmetry', 'c1')
+    kwargs.setdefault('charge', 0)
+    kwargs.setdefault('multiplicity', 1)
+
+    mol_geometry = kwargs['mol_geometry']
+    basis = kwargs['basis']
+    multiplicity = kwargs['multiplicity']
+    charge = kwargs['charge']
+
+    qforte_mol = Molecule(
+        mol_geometry = mol_geometry,
+        basis = basis,
+        multiplicity = multiplicity,
+        charge = charge,
+        )
+
+    if not use_pyscf:
+        raise ImportError("PySCF was not imported correctely.")
+
+    # By default, the number of frozen orbitals is set to zero
+    kwargs.setdefault('num_frozen_docc', 0)
+    kwargs.setdefault('num_frozen_uocc', 0)
+
+    # run_scf is not read, because we always run SCF to get a wavefunction object.
+    kwargs.setdefault('run_mp2', False)
+    kwargs.setdefault('run_ccsd', False)
+    kwargs.setdefault('run_cisd', False)
+    kwargs.setdefault('run_fci', False)
+
+    # ===> Run PySCF End <=== #
+
+    pyscf_geom_str = ""
+
+    for geom_line in mol_geometry:
+        pyscf_geom_str += f"\n{geom_line[0]}  {geom_line[1][0]}  {geom_line[1][1]}  {geom_line[1][2]}"
+
+    print(' ==> PySCF geometry <==')
+    print('-------------------------')
+    print(pyscf_geom_str)
+
+    # Determine the spin (number of unpaired electrons)
+    spin = multiplicity - 1
+
+    # Create the molecule object
+    pyscf_mol = mol = gto.Mole()
+    pyscf_mol.build(
+        atom=pyscf_geom_str,
+        basis=basis,
+        charge=charge,
+        spin=spin,
+        symmetry = True,
+        symmetry_subgroup = kwargs.get('symmetry', 'c1')
+    )
+
+    # Determine the reference type
+
+    if multiplicity != 1:
+        raise ValueError(f"Unsupported multiplicity: {multiplicity}, currently unsupporded")
+
+    mf = scf.RHF(pyscf_mol)
+
+    # Set convergence options
+    mf.conv_tol = 1e-8          # Energy convergence criterion
+    mf.conv_tol_grad = 1e-8     # Density convergence criterion
+
+    # Perform the SCF calculation
+    pyscf_Escf = mf.kernel()
+    # pyscf_wfn = mf  # Wavefunction object analogous to Psi4's wfn
+
+    # Perform additional computations if requested
+    if kwargs.get('run_mp2', False):
+        num_frozen_docc = kwargs.get('num_frozen_docc', 0)
+        num_frozen_uocc = kwargs.get('num_frozen_uocc', 0)
+        nmo = mf.mo_coeff.shape[1]
+        nocc = mol.nelectron // 2
+
+        # Build list of frozen orbitals
+        frozen = []
+        if num_frozen_docc > 0:
+            frozen += list(range(num_frozen_docc))  # Freeze core orbitals
+        if num_frozen_uocc > 0:
+            frozen += list(range(nmo - num_frozen_uocc, nmo))  # Freeze virtual orbitals
+
+        if frozen:
+            mymp = mp.MP2(mf).set(frozen=frozen)
+        else:
+            mymp = mp.MP2(mf)
+        mp2_energy, _ = mymp.kernel()
+
+        # Store the MP2 energy
+        qforte_mol = lambda: None  # Placeholder for your data structure
+        qforte_mol.mp2_energy = mp2_energy
+
+    if kwargs.get('run_fci', False):
+        if kwargs.get('num_frozen_uocc', 0) == 0:
+            cisolver = fci.FCI(mf)
+            fci_energy, _ = cisolver.kernel()
+            qforte_mol.fci_energy = fci_energy
+        else:
+            print('\nWARNING: Skipping FCI computation due to frozen virtual orbitals not being supported in PySCF FCI.\n')
+
+    # Get the MO coefficients
+    C = mf.mo_coeff
+
+    # Get the scalar variables (nuclear repulsion energy)
+    pyscf_Enuc_ref = mol.energy_nuc()
+
+    # Get one-electron integrals and transform to MO basis
+    h_core = mf.get_hcore()
+    mo_oeis = C.T @ h_core @ C  # Transformed one-electron integrals
+
+    # Get two-electron integrals and transform to MO basis
+    nmo = C.shape[1]
+    # AO to MO transformation of two-electron integrals
+    mo_teis = ao2mo.kernel(mol, C, compact=False).reshape(nmo, nmo, nmo, nmo)
+
+    # Get the number of alpha and beta electrons
+    nalpha, nbeta = mol.nelec
+    nel = nalpha + nbeta
+
+    # ===> Run PySCF End <=== #
+
+    # ===> Get more PySCF info <=== #
+
+    # Retrieve the number of frozen core and virtual orbitals
+    frozen_core = kwargs.get('num_frozen_docc', 0)
+    frozen_virtual = kwargs.get('num_frozen_uocc', 0)
+
+    # Get symmetry information
+    point_group = mol.groupname.lower()
+    S = mol.intor('int1e_ovlp')
+    irreps_pyscf = symm.label_orb_symm(mol, mol.irrep_name, mol.symm_orb, C, S)
+    irreps_qforte = qforte.irreps_of_point_groups(point_group)
+    irrep_to_index = {irrep : idx for idx, irrep in enumerate(irreps_qforte)}
+
+    # Build the list of orbitals with their energies and irrep indices
+    orbitals = []
+    for i in range(len(mf.mo_energy)):
+        orbital_energy = mf.mo_energy[i]
+        irrep_name = irreps_pyscf[i]
+        irrep_idx = irrep_to_index[irrep_name]
+        orbitals.append([orbital_energy, irrep_idx])
+
+    # Sort orbitals by energy
+    orbitals.sort()
+
+    # Extract orbital energies and irrep indices
+    hf_orbital_energies = []
+    orb_irreps_to_int = []
+    for row in orbitals:
+        hf_orbital_energies.append(row[0])
+        orb_irreps_to_int.append(row[1])
+
+    # print('\n\n')
+    # print(f"Pyscf orbitals {orbitals}")
+    # print(f"Pyscf point_group {point_group}")
+    # print(f"Pyscf orb_irreps_to_int {orb_irreps_to_int}")
+    # print(f"Pyscf irreps {irreps_qforte}")
+    # print('\n\n')
+
+    orb_irreps = [irreps_qforte[i] for i in orb_irreps_to_int]
+
+
+    # Compute the frozen core energy
+    frozen_core_energy = 0.0
+
+    if frozen_core > 0:
+        # Sum over frozen core orbitals
+        for i in range(frozen_core):
+            frozen_core_energy += 2 * mo_oeis[i, i]
+
+        for i in range(frozen_core):
+            for j in range(frozen_core):
+                frozen_core_energy += 2 * mo_teis[i, i, j, j] - mo_teis[i, j, j, i]
+
+        # Adjust the one-electron integrals to account for frozen core orbitals
+        for p in range(frozen_core, nmo - frozen_virtual):
+            for q in range(frozen_core, nmo - frozen_virtual):
+                for i in range(frozen_core):
+                    mo_oeis[p, q] += 2 * mo_teis[p, q, i, i] - mo_teis[p, i, i, q]
+
+    # Build the Hartree-Fock reference configuration
+    num_active_orbitals = nmo - frozen_core - frozen_virtual
+    num_active_electrons = nel - 2 * frozen_core
+    hf_reference = [1] * num_active_electrons + [0] * (2 * num_active_orbitals - num_active_electrons)
+
+    # Build second quantized Hamiltonian
+    Hsq = qforte.SQOperator()
+    Hsq.add(pyscf_Enuc_ref + frozen_core_energy, [], [])
+    for i in range(frozen_core, nmo - frozen_virtual):
+        ia = (i - frozen_core)*2
+        ib = (i - frozen_core)*2 + 1
+        for j in range(frozen_core, nmo - frozen_virtual):
+            ja = (j - frozen_core)*2
+            jb = (j - frozen_core)*2 + 1
+
+            Hsq.add(mo_oeis[i,j], [ia], [ja])
+            Hsq.add(mo_oeis[i,j], [ib], [jb])
+
+            for k in range(frozen_core, nmo - frozen_virtual):
+                ka = (k - frozen_core)*2
+                kb = (k - frozen_core)*2 + 1
+                for l in range(frozen_core, nmo - frozen_virtual):
+                    la = (l - frozen_core)*2
+                    lb = (l - frozen_core)*2 + 1
+
+                    if(ia!=jb and kb != la):
+                        Hsq.add( mo_teis[i,l,k,j]/2, [ia, jb], [kb, la] ) # abba
+                    if(ib!=ja and ka!=lb):
+                        Hsq.add( mo_teis[i,l,k,j]/2, [ib, ja], [ka, lb] ) # baab
+
+                    if(ia!=ja and ka!=la):
+                        Hsq.add( mo_teis[i,l,k,j]/2, [ia, ja], [ka, la] ) # aaaa
+                    if(ib!=jb and kb!=lb):
+                        Hsq.add( mo_teis[i,l,k,j]/2, [ib, jb], [kb, lb] ) # bbbb
+
+    # ===> Get More PySCF Attributes END <=== #
+
+    # Set attributes
+    qforte_mol.nuclear_repulsion_energy = pyscf_Enuc_ref
+    qforte_mol.hf_energy = pyscf_Escf
+    qforte_mol.hf_reference = hf_reference
+    qforte_mol.sq_hamiltonian = Hsq
+    if kwargs['build_qb_ham']:
+        qforte_mol.hamiltonian = Hsq.jw_transform()
+    else:
+        Hsq.simplify()
+        qforte_mol.hamiltonian = None
+
+    qforte_mol.point_group = [point_group, irreps_qforte]
+    qforte_mol.orb_irreps = orb_irreps
+    qforte_mol.orb_irreps_to_int = orb_irreps_to_int
+    qforte_mol.hf_orbital_energies = hf_orbital_energies
+    qforte_mol.frozen_core = frozen_core
+    qforte_mol.frozen_virtual = frozen_virtual
+    qforte_mol.frozen_core_energy = frozen_core_energy
+
+    if kwargs['build_df_ham']:
+        if not kwargs['store_mo_ints']:
+            raise ValueError("store_mo_ints must be True if you want to build_df_ham")
+        else:
+            pyscf_mo_oeis = copy.deepcopy(mo_oeis)
+            pyscf_mo_teis = copy.deepcopy(mo_teis)
+
+    if kwargs['store_mo_ints']:
+
+        # keep ordering consistant with openfermion eri tensors
+        mo_teis = np.asarray(mo_teis.transpose(0, 2, 3, 1), order='C')
+
+        # need restricted version
+        h2e_rest = copy.deepcopy(np.einsum("ijlk", -0.5 * mo_teis))
+
+        # additoinal manipulation
+        h1e = copy.deepcopy(mo_oeis)
+        h2e = np.moveaxis(copy.deepcopy(h2e_rest), 1, 2) * (-1.0)
+        h1e -= np.einsum('ikkj->ij', h2e)
+
+        # just going to precumpute the einseum (for now)
+        h2e_einsum = copy.deepcopy(h2e + np.einsum('ijkl->klij', h2e))
+
+        # allocate qf tensors
+        qf_mo_oeis = qforte.Tensor(shape=np.shape(h1e), name='mo_oeis')
+        qf_mo_teis = qforte.Tensor(shape=np.shape(h2e), name='mo_teis')
+        qf_mo_teis_einsum = qforte.Tensor(shape=np.shape(h2e_einsum), name='mo_teis_einsum')
+        
+        # fill qf tensors
+        qf_mo_oeis.fill_from_nparray(h1e.ravel(), np.shape(h1e))
+        qf_mo_teis.fill_from_nparray(h2e.ravel(), np.shape(h2e)) 
+        qf_mo_teis_einsum.fill_from_nparray(
+            h2e_einsum.ravel(), 
+            np.shape(h2e_einsum)) 
+
+        qforte_mol.mo_oeis = qf_mo_oeis
+        qforte_mol.mo_teis = qf_mo_teis
+        qforte_mol.mo_teis_einsum = qf_mo_teis_einsum
+
+        # TODO(Nick), If we want better controll over this, it there shuld be a molecule member function that
+        # builds the df_ham from the stored mo_oeis and mo_teis rather than building it when pyscf 
+        # is initially run!
+        if kwargs['build_df_ham']:
+            raise NotImplementedError("WARNING: Building DF Hamiltonain using pyscf is not tested")
+            # keep ordering consistant with openfermion eri tensors
+            pyscf_mo_teis = np.asarray(pyscf_mo_teis.transpose(0, 2, 3, 1), order='C')
+
+            # do first factorization from integrals
+            ff_eigenvalues, one_body_squares, one_body_correction = first_factorization(
+                tei = pyscf_mo_teis,
+                lmax=None, # change if we want 
+                spin_basis=False,
+                threshold=kwargs['df_icut']) # may be very important to play with
+            
+            # do second factorization based on integrals and first factorizaiotn
+            scaled_density_density_matrices, basis_change_matrices = second_factorization(
+                ff_eigenvalues, 
+                one_body_squares)
+        
+            trotter_basis_change_matrices = [
+                # basis_change_matrices[0] @ expm(-1.0j * (p4_mo_oeis + one_body_correction[::2, ::2]))
+                np.zeros(shape=(nmo,nmo))
+            ]
+
+            for ii in range(len(basis_change_matrices) - 1):
+
+                trotter_basis_change_matrices.append(
+                    basis_change_matrices[ii + 1] @ basis_change_matrices[ii].conj().T)
+            
+            trotter_basis_change_matrices.append(basis_change_matrices[ii + 1].conj().T)
+
+            qf_ff_eigenvalues = qforte.Tensor(
+                shape=np.shape(ff_eigenvalues), 
+                name='first_factorization_eigenvalues')
+            
+            qf_one_body_squares = qforte.Tensor(
+                shape=np.shape(one_body_squares), 
+                name='one_body_squares')
+            
+            qf_one_body_ints = qforte.Tensor(
+                shape=np.shape(pyscf_mo_oeis), 
+                name='one_body_ints')
+            
+            qf_one_body_correction = qforte.Tensor(
+                shape=np.shape(one_body_correction[::2, ::2]), 
+                name='one_body_correction')
+            
+            qf_ff_eigenvalues.fill_from_nparray(
+                ff_eigenvalues.ravel(), 
+                np.shape(ff_eigenvalues))
+            
+            qf_one_body_squares.fill_from_nparray(
+                one_body_squares.ravel(), 
+                np.shape(one_body_squares))
+            
+            qf_one_body_ints.fill_from_nparray(
+                pyscf_mo_oeis.ravel(), 
+                np.shape(pyscf_mo_oeis))
+            
+            qf_one_body_correction.fill_from_nparray(
+                one_body_correction[::2, ::2].ravel(), 
+                np.shape(one_body_correction[::2, ::2]))
+            
+            # ===> convert lists of numpy arrays to lists of qforte Tensors
+
+            qf_scaled_density_density_matrices = []
+
+            for l in range(len(scaled_density_density_matrices)):
+            
+                qf_scaled_density_density_mat = qforte.Tensor(
+                    shape=np.shape(scaled_density_density_matrices[l]), 
+                    name=f'scaled_density_density_matrices_{l}')
+                
+                qf_scaled_density_density_mat.fill_from_nparray(
+                scaled_density_density_matrices[l].ravel(), 
+                np.shape(scaled_density_density_matrices[l]))
+
+                qf_scaled_density_density_matrices.append(
+                    qf_scaled_density_density_mat
+                )
+            
+
+            qf_basis_change_matrices = []
+
+            for l in range(len(basis_change_matrices)):
+                qf_basis_change_mat = qforte.Tensor(
+                    shape=np.shape(basis_change_matrices[l]), 
+                    name=f'basis_change_matrices_{l}')
+                
+                qf_basis_change_mat.fill_from_nparray(
+                    basis_change_matrices[l].ravel(), 
+                    np.shape(basis_change_matrices[l]))
+            
+                qf_basis_change_matrices.append(
+                    qf_basis_change_mat
+                )
+
+            
+            qf_trotter_basis_change_matrices = []
+            for l in range(len(trotter_basis_change_matrices)):
+
+                qf_trotter_basis_change_mat = qforte.Tensor(
+                    shape=np.shape(trotter_basis_change_matrices[l]), 
+                    name=f'trotter_basis_change_matrices_{l}')
+                
+                
+                qf_trotter_basis_change_mat.fill_from_nparray(
+                    trotter_basis_change_matrices[l].ravel(), 
+                    np.shape(trotter_basis_change_matrices[l]))
+                
+                qf_trotter_basis_change_matrices.append(
+                    qf_trotter_basis_change_mat
+                )
+
+            qforte_mol._df_ham = qforte.DFHamiltonian(
+                nel=nel,
+                norb=nmo,
+                eigenvalues = qf_ff_eigenvalues,
+                one_body_squares = qf_one_body_squares,
+                one_body_ints = qf_one_body_ints,
+                one_body_correction = qf_one_body_correction,
+                scaled_density_density_matrices = qf_scaled_density_density_matrices,
+                basis_change_matrices = qf_basis_change_matrices,
+                trotter_basis_change_matrices = qf_trotter_basis_change_matrices
+            )
 
     return qforte_mol
 

--- a/src/qforte/hva/hvavqe.py
+++ b/src/qforte/hva/hvavqe.py
@@ -350,7 +350,7 @@ class HVAVQE(UCCVQE):
             if(self._apply_ham_as_tensor):
                 
                 val = self._qc.get_exp_val_tensor(
-                        self._nuclear_repulsion_energy, 
+                        self._zero_body_energy, 
                         self._mo_oeis, 
                         self._mo_teis, 
                         self._mo_teis_einsum, 
@@ -448,7 +448,7 @@ class HVAVQE(UCCVQE):
 
         if(self._apply_ham_as_tensor):
             qc_sig.apply_tensor_spat_012bdy(
-                self._nuclear_repulsion_energy, 
+                self._zero_body_energy, 
                 self._mo_oeis, 
                 self._mo_teis, 
                 self._mo_teis_einsum, 

--- a/src/qforte/ite/qite.py
+++ b/src/qforte/ite/qite.py
@@ -234,7 +234,7 @@ class QITE(Algorithm):
                 if(self._apply_ham_as_tensor):
 
                     self._Ekb = [np.real(qc_ref.get_exp_val_tensor(
-                            self._nuclear_repulsion_energy, 
+                            self._zero_body_energy, 
                             self._mo_oeis, 
                             self._mo_teis, 
                             self._mo_teis_einsum, 
@@ -262,7 +262,7 @@ class QITE(Algorithm):
         self.evolve()
 
         timer.record('Total evolution time')
-        print(timer)
+        print(f"\n\n{timer}\n\n")
 
         # Print summary banner (should done for all algorithms).
         self.print_summary_banner()
@@ -450,7 +450,7 @@ class QITE(Algorithm):
         else:
             if(self._apply_ham_as_tensor):
                 Hpsi_qc.apply_tensor_spat_012bdy(
-                        self._nuclear_repulsion_energy, 
+                        self._zero_body_energy, 
                         self._mo_oeis, 
                         self._mo_teis, 
                         self._mo_teis_einsum, 
@@ -686,7 +686,7 @@ class QITE(Algorithm):
 
                 if(self._apply_ham_as_tensor):
                     self._Ekb.append(np.real(self._qc.get_exp_val_tensor(
-                            self._nuclear_repulsion_energy, 
+                            self._zero_body_energy, 
                             self._mo_oeis, 
                             self._mo_teis, 
                             self._mo_teis_einsum, 
@@ -746,7 +746,7 @@ class QITE(Algorithm):
 
                 if(self._apply_ham_as_tensor):
                     qcSig_temp.apply_tensor_spat_012bdy(
-                            self._nuclear_repulsion_energy, 
+                            self._zero_body_energy, 
                             self._mo_oeis, 
                             self._mo_teis, 
                             self._mo_teis_einsum, 
@@ -776,7 +776,7 @@ class QITE(Algorithm):
             if(self._use_exact_evolution):
                 if(self._apply_ham_as_tensor):
                     self._qc.evolve_tensor_taylor(
-                            self._nuclear_repulsion_energy, 
+                            self._zero_body_energy, 
                             self._mo_oeis, 
                             self._mo_teis, 
                             self._mo_teis_einsum, 
@@ -794,7 +794,7 @@ class QITE(Algorithm):
                     # print(f'norm after scaling: {self._qc.get_state().norm()}')
 
                     self._Ekb.append(np.real(self._qc.get_exp_val_tensor(
-                            self._nuclear_repulsion_energy, 
+                            self._zero_body_energy, 
                             self._mo_oeis, 
                             self._mo_teis, 
                             self._mo_teis_einsum, 
@@ -835,7 +835,7 @@ class QITE(Algorithm):
                     if(self._physical_r):
                         if(self._apply_ham_as_tensor):
                             qc_res.evolve_tensor_taylor(
-                                self._nuclear_repulsion_energy, 
+                                self._zero_body_energy, 
                                 self._mo_oeis, 
                                 self._mo_teis, 
                                 self._mo_teis_einsum, 
@@ -856,7 +856,7 @@ class QITE(Algorithm):
                     else:
                         if(self._apply_ham_as_tensor):
                             qc_res.apply_tensor_spat_012bdy(
-                                self._nuclear_repulsion_energy, 
+                                self._zero_body_energy, 
                                 self._mo_oeis, 
                                 self._mo_teis, 
                                 self._mo_teis_einsum, 
@@ -933,7 +933,7 @@ class QITE(Algorithm):
 
                             if(self._apply_ham_as_tensor):
                                 qcSig_temp.apply_tensor_spat_012bdy(
-                                    self._nuclear_repulsion_energy, 
+                                    self._zero_body_energy, 
                                     self._mo_oeis, 
                                     self._mo_teis, 
                                     self._mo_teis_einsum, 

--- a/src/qforte/qkd/srcd.py
+++ b/src/qforte/qkd/srcd.py
@@ -192,7 +192,7 @@ class SRCD(QSD):
 
                 if(self._apply_ham_as_tensor):
                     QC.apply_tensor_spat_012bdy(
-                        self._nuclear_repulsion_energy, 
+                        self._zero_body_energy, 
                         self._mo_oeis, 
                         self._mo_teis, 
                         self._mo_teis_einsum, 
@@ -235,7 +235,7 @@ class SRCD(QSD):
 
             if(self._apply_ham_as_tensor):
                 QC.apply_tensor_spat_012bdy(
-                    self._nuclear_repulsion_energy, 
+                    self._zero_body_energy, 
                     self._mo_oeis, 
                     self._mo_teis, 
                     self._mo_teis_einsum, 

--- a/src/qforte/qkd/srqd.py
+++ b/src/qforte/qkd/srqd.py
@@ -181,7 +181,7 @@ class SRQD(Algorithm):
 
             if(self._apply_ham_as_tensor):
                 self._qc.apply_tensor_spat_012bdy(
-                    self._nuclear_repulsion_energy, 
+                    self._zero_body_energy, 
                     self._mo_oeis, 
                     self._mo_teis, 
                     self._mo_teis_einsum, 

--- a/src/qforte/qkd/srqk.py
+++ b/src/qforte/qkd/srqk.py
@@ -431,7 +431,7 @@ class SRQK(QSD):
 
             if(self._apply_ham_as_tensor):
                 QC.apply_tensor_spat_012bdy(
-                    self._nuclear_repulsion_energy, 
+                    self._zero_body_energy, 
                     self._mo_oeis, 
                     self._mo_teis, 
                     self._mo_teis_einsum, 

--- a/src/qforte/qkd/troubleshoot_srqd.py
+++ b/src/qforte/qkd/troubleshoot_srqd.py
@@ -142,7 +142,7 @@ class SRQD(Algorithm):
 
                 if(self._apply_ham_as_tensor):
                     self._qc.apply_tensor_spat_012bdy(
-                        self._nuclear_repulsion_energy, 
+                        self._zero_body_energy, 
                         self._mo_oeis, 
                         self._mo_teis, 
                         self._mo_teis_einsum, 

--- a/src/qforte/system/system_factory.py
+++ b/src/qforte/system/system_factory.py
@@ -25,7 +25,8 @@ def system_factory(system_type = 'molecule', build_type = 'psi4', **kwargs):
 
     molecule_adapters = {
         "external": MA.create_external_mol,
-        "psi4": MA.create_psi_mol
+        "psi4": MA.create_psi_mol,
+        "pyscf": MA.create_pyscf_mol
     }
 
     model_adapters = {

--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -443,7 +443,7 @@ class SPQE(UCCPQE):
 
         if(self._apply_ham_as_tensor):
             qc_res.apply_tensor_spat_012bdy(
-            self._nuclear_repulsion_energy, 
+            self._zero_body_energy, 
             self._mo_oeis, 
             self._mo_teis, 
             self._mo_teis_einsum, 

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -376,7 +376,7 @@ class UCCNPQE(UCCPQE):
 
         if(self._apply_ham_as_tensor):
             qc_res.apply_tensor_spat_012bdy(
-                self._nuclear_repulsion_energy, 
+                self._zero_body_energy, 
                 self._mo_oeis, 
                 self._mo_teis, 
                 self._mo_teis_einsum, 


### PR DESCRIPTION
## Description
This PR adds a PySCF interface to qforte. Using the same syntax as prior, one can specify build_type='pyscf' in the system factory and populate all the relevant intermediates as psi4 could do previously. One can also specify frozen occupied and unoccupied orbitals. Example code for how to run such calculations is providied in sandbox/pyscf_adapter/test_v2.py

Notably the PySCF interface can also no use AVAS for automated active space selection (see AVAS documentation). Example code can be found in sandbox/pyscf_adapter/test_v4.py for octane.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [ ] Ready to go!
