### PR TITLE
Using DIIS with QITE

### DIFF
--- a/sandbox/qite/test_qite_diis_v1.py
+++ b/sandbox/qite/test_qite_diis_v1.py
@@ -1,0 +1,73 @@
+from qforte import Molecule, QITE, system_factory
+
+# The FCI energy for H2 at 1.5 Angstrom in a sto-3g basis
+# E_fci = -0.9981493534
+# E_fock = -0.9108735544
+
+print('\nBuild Psi4 Geometry')
+print('-------------------------')
+
+geom = [('H', (0., 0., 0.)), 
+        ('H', (0., 0., 1.00)),
+        ('H', (0., 0., 2.00)), 
+        ('H', (0., 0., 3.00)),
+        ('H', (0., 0., 4.00)),
+        ('H', (0., 0., 5.00)),
+        # ('H', (0., 0., 6.00)), 
+        # ('H', (0., 0., 7.00)), 
+        ]
+
+
+# Get the molecule object that now contains both the fermionic and qubit Hamiltonians.
+mol = system_factory(build_type='psi4', 
+                     mol_geometry=geom, 
+                     basis='sto-6g', 
+                     run_fci=True, 
+                     run_ccsd=False,
+                     store_mo_ints=1,
+                     build_df_ham=1,
+                     df_icut=1.0e-1)
+
+# mol.ccsd_energy = 0.0
+
+print(f'The FCI energy from Psi4:                                    {mol.fci_energy:12.10f}')
+print(f'The HF energy from Psi4:                                     {mol.hf_energy:12.10f}')
+
+print('\nBegin QITE test for H8 2nd order')
+print('-------------------------')
+
+alg = QITE(mol, 
+        reference=mol.hf_reference, 
+        computer_type='fci', 
+        verbose=0, 
+        print_summary_file=0,
+        apply_ham_as_tensor=True)
+
+alg.run(beta=10.0, 
+        db=0.50,
+        dt=0.001,
+        use_exact_evolution=False,   # <==== Nothing else matters if using exact evo
+        use_diis=True,               # <==== Manin new option here
+        max_diis_size=6,             # <==== Max number of previous iterations to use in DIIS
+        sparseSb=0,
+        expansion_type='SD', #All 
+        low_memorySb=False,
+        second_order=True, 
+        print_pool=1, 
+        evolve_dfham=False, 
+        random_state=False, 
+        selected_pool=False,
+        physical_r=True,
+        cumulative_t=True,
+        t_thresh=1e-4)
+
+Egs_FCI = alg.get_gs_energy()
+
+
+print(f'The HF energy from Psi4:                                     {mol.hf_energy:12.10f}')
+print(f'The FCI energy from Psi4:                                    {mol.fci_energy:12.10f}')
+
+print(f'The FCI energy from FCI QITE:                                {Egs_FCI:12.10f}')
+print(f'The FCI energy error:                                        {Egs_FCI - mol.fci_energy:12.10f}')
+
+

--- a/sandbox/qite/test_qite_diis_v2.py
+++ b/sandbox/qite/test_qite_diis_v2.py
@@ -1,0 +1,90 @@
+import qforte as qf
+
+print('\nBuild Geometry')
+print('-------------------------')
+
+symm_str = 'c1'
+fdocc = 0
+fuocc = 0
+
+basis_set = 'cc-pvdz'
+avas_atoms_and_atomic_orbs = ['C 2pz']
+
+# 8-ene geom
+geom = [
+('C', ( 0.335863334534,    -0.638024393629,    -0.000000000000)),
+('H', ( 1.432938652990,    -0.620850836653,    -0.000000000000)),
+('C', (-0.296842857597,    -1.839541058429,     0.000000000000)),
+('H', (-1.393739535698,    -1.860704460450,     0.000000000000)),
+('C', ( 0.383204712221,    -3.118962195977,     0.000000000000)),
+('H', ( 1.479554414548,    -3.087255036285,     0.000000000000)),
+('C', (-0.237579216697,    -4.313790116847,     0.000000000000)),
+('H', ( 0.325161369217,    -5.249189992705,     0.000000000000)),
+('H', (-1.329245260575,    -4.386987278270,     0.000000000000)),
+('C', (-0.335863334534,     0.638024393629,     0.000000000000)),
+('H', (-1.432938652990,     0.620850836653,     0.000000000000)),
+('C', ( 0.296842857597,     1.839541058429,     0.000000000000)),
+('H', ( 1.393739535698,     1.860704460450,     0.000000000000)),
+('C', (-0.383204712221,     3.118962195977,     0.000000000000)),
+('H', (-1.479554414548,     3.087255036285,     0.000000000000)),
+('C', ( 0.237579216697,     4.313790116847,     0.000000000000)),
+('H', ( 1.329245260575,     4.386987278270,     0.000000000000)),
+('H', (-0.325161369217,     5.249189992705,     0.000000000000)),
+        ]
+
+
+## ====> Build Qforte Mol with PySCF (using AVAS) <==== ###
+mol = qf.system_factory(
+    build_type='pyscf', 
+    symmetry=symm_str,
+    mol_geometry=geom, 
+    basis=basis_set, 
+    run_fci=True, 
+    use_avas=True, #                     <=====
+    avas_atoms_or_orbitals=avas_atoms_and_atomic_orbs,
+    run_ccsd=False,
+    store_mo_ints=True,
+    build_df_ham=False,
+    num_frozen_uocc = fuocc,
+    num_frozen_docc = fdocc,
+    build_qb_ham = False,
+    )
+
+print('\nBegin QITE test for H8 2nd order')
+print('-------------------------')
+
+alg = qf.QITE(mol, 
+        reference=mol.hf_reference, 
+        computer_type='fci', 
+        verbose=0, 
+        print_summary_file=0,
+        apply_ham_as_tensor=True)
+
+alg.run(beta=10.0, 
+        db=0.10,
+        dt=0.001,
+        use_exact_evolution=True,   # <==== Nothing else matters if using exact evo
+        use_diis=True,               # <==== Manin new option here
+        max_diis_size=6,             # <==== Max number of previous iterations to use in DIIS
+        sparseSb=0,
+        expansion_type='SD', #All 
+        low_memorySb=False,
+        second_order=True, 
+        print_pool=1, 
+        evolve_dfham=False, 
+        random_state=False, 
+        selected_pool=False,
+        physical_r=True,
+        cumulative_t=True,
+        t_thresh=1e-4)
+
+Egs_FCI = alg.get_gs_energy()
+
+
+print(f'The HF energy from Pscf:                                     {mol.hf_energy:12.10f}')
+print(f'The FCI energy from Pscf:                                    {mol.fci_energy:12.10f}')
+
+print(f'The FCI energy from FCI QITE:                                {Egs_FCI:12.10f}')
+print(f'The FCI energy error:                                        {Egs_FCI - mol.fci_energy:12.10f}')
+
+

--- a/src/qforte/ite/qite.py
+++ b/src/qforte/ite/qite.py
@@ -125,6 +125,8 @@ class QITE(Algorithm):
             beta=1.0,
             db=0.2,
             dt=0.01,
+            use_diis=False,
+            max_diis_size=False,
             use_exact_evolution=False,
             expansion_type='SD',
             evolve_dfham=False,
@@ -163,6 +165,10 @@ class QITE(Algorithm):
         self._b_thresh = b_thresh
         self._x_thresh = x_thresh
         self._physical_r = physical_r
+
+        # DIIS options
+        self._use_diis = use_diis
+        self._qite_diis_max = max_diis_size
 
         self._n_classical_params = 0
         self._n_cnot = self._Uprep.get_num_cnots()
@@ -251,9 +257,16 @@ class QITE(Algorithm):
         # Print options banner (should done for all algorithms).
         self.print_options_banner()
 
+        # NOTE(Nick): temporary, just want diis to work as expected.
+        self._tamps = []
+
         # Build expansion pool.
         if(not self._use_exact_evolution):
             self.build_expansion_pool()
+
+        self._t_diis = [copy.deepcopy(self._tamps)]
+        self._e_diis = []
+        
 
         # Do the imaginary time evolution.
         timer = qf.local_timer()
@@ -299,17 +312,32 @@ class QITE(Algorithm):
         print('Total imaginary evolution time (beta):   ',  self._beta)
         print('Imaginary time step (db):                ',  self._db)
         print('Use exact evolution:                     ',  self._use_exact_evolution)
-        print('Expansion type:                          ',  self._expansion_type)
-        print('x value threshold:                       ',  self._x_thresh)
-        print('Use sparse tensors to solve Sx = b:      ',  str(self._sparseSb))
-        if(self._sparseSb):
-            print('b value threshold:                       ',  str(self._b_thresh))
-        print('\n')
-        print('Use low memory mode:                     ',  self._low_memorySb)
-        print('Use 2nd order derivation of QITE:        ',  self._second_order)
+
+        if not self._use_exact_evolution:
+            print('Expansion type:                          ',  self._expansion_type)
+            print('Use DIIS:                                ',  self._use_diis)
+            print('Max DIIS size:                           ',  self._qite_diis_max)
+        
+            print('Use selected pool:                       ',  self._selected_pool)
+            if self._selected_pool:
+                print('Use cumulative selection:                ',  self._cumulative_t)
+                print('Use physical selection:                  ',  self._physical_r)
+                print('Selection time step (dt):                ',  self._dt)
+
+        
+            print('x value threshold:                       ',  self._x_thresh)
+            print('Use sparse tensors to solve Sx = b:      ',  str(self._sparseSb))
+            if(self._sparseSb):
+                print('b value threshold:                       ',  str(self._b_thresh))
+            print('\n')
+            print('Use low memory mode:                     ',  self._low_memorySb)
+            print('Use 2nd order derivation of QITE:        ',  self._second_order)
+
         print('Do Quantum Lanczos                       ',  str(self._do_lanczos))
         if(self._do_lanczos):
             print('Lanczos gap size                         ',  self._lanczos_gap)
+
+        print('\n\n')
 
     def print_summary_banner(self):
         print('\n\n                        ==> QITE summary <==')
@@ -417,6 +445,8 @@ class QITE(Algorithm):
                 raise ValueError('Invalid expansion type specified.')
 
             self._NI = len(self._sig.terms())
+
+        self._tamps = list(np.zeros(self._NI))
 
 
     def build_S_b_FCI(self):
@@ -622,6 +652,11 @@ class QITE(Algorithm):
         # this is only for UCC!
         x_list_fci = [x*self._db for x in x_list]
 
+        # Also used only for DIIS
+        told = copy.deepcopy(self._tamps)
+        self._tamps = self._tamps = list(np.add(self._tamps, x_list_fci))
+        evec = list(np.subtract(self._tamps, told))
+
         if(self._computer_type=='fock'):
             if(self._sparseSb):
                 for I, spI in enumerate(sp_idxs):
@@ -678,7 +713,22 @@ class QITE(Algorithm):
                 self._qc.set_state(exp1)
 
             else:
-                self._sig.set_coeffs(x_list_fci)
+                if(self._use_diis):
+
+                    self._t_diis.append(copy.deepcopy(self._tamps))
+                    self._e_diis.append(copy.deepcopy(evec))
+
+                    self._tamps = self.qite_diis(
+                        self._qite_diis_max,
+                        self._t_diis,
+                        self._e_diis)
+                    
+                    x_list_fci_diis = list(np.subtract(self._tamps, told))
+                    self._sig.set_coeffs(x_list_fci_diis)
+                
+                else:
+                    self._sig.set_coeffs(x_list_fci)
+
                 self._qc.evolve_pool_trotter_basic(
                     self._sig, 
                     1, 
@@ -969,3 +1019,39 @@ class QITE(Algorithm):
         print('\nQITE expansion operators:')
         print('-------------------------')
         print(self._sig.str())
+
+
+    # NOTE(Nick): Presently this is identical to the pqe/vqe diis, likely can be optemized for qite,
+    # We will also want a version that works with selection
+    def qite_diis(self, diis_max_dim, t_diis, e_diis):
+        """This function implements the direct inversion of iterative subspace
+        (DIIS) convergence accelerator. Draws heavy insiration from Daniel
+        Smith's ccsd_diss.py code in psi4 numpy
+        """
+
+        if len(t_diis) > diis_max_dim:
+            del t_diis[0]
+            del e_diis[0]
+
+        diis_dim = len(t_diis) - 1
+
+        # Construct diis B matrix (following Crawford Group github tutorial)
+        B = np.ones((diis_dim+1, diis_dim+1)) * -1
+        bsol = np.zeros(diis_dim+1)
+
+        B[-1, -1] = 0.0
+        bsol[-1] = -1.0
+        for i, ei in enumerate(e_diis):
+            for j, ej in enumerate(e_diis):
+                B[i,j] = np.dot(np.real(ei), np.real(ej))
+
+        B[:-1, :-1] /= np.abs(B[:-1, :-1]).max()
+
+        x = np.linalg.lstsq(B, bsol, rcond=None)[0][:-1]
+
+        t_new = np.zeros(( len(t_diis[0]) ))
+        for l in range(diis_dim):
+            temp_ary = x[l] * np.asarray(t_diis[l+1])
+            t_new = np.add(t_new, temp_ary)
+
+        return copy.deepcopy(list(np.real(t_new)))


### PR DESCRIPTION
## Description
This PR adds the ability to use DIIS (direct inversion of iterative subspace) within the QITE iterations. Seems to accelerate convergence and confirm idea that accuracy is limited by ansatz. Currently only works with fixed-ansatz (as opposed to selected) QITE. sandbox tests are provided (both for H8, and octane (with pyscf avas)). 

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [ ] Ready to go!
