### PR TITLE
Adds full cnot counter and T counter to SQOperator class

### DIFF
--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -62,6 +62,8 @@ PYBIND11_MODULE(qforte, m) {
         .def("count_unique_pauli_products", &SQOperator::count_unique_pauli_products, 
             py::arg("B") = nullptr)
         .def("count_cnot_for_exponential", &SQOperator::count_cnot_for_exponential)
+        .def("count_cnot_for_exponential_full", &SQOperator::count_cnot_for_exponential_full)
+        .def("count_T_for_exponential_full", &SQOperator::count_T_for_exponential_full)
         .def("str", &SQOperator::str)
         .def("__str__", &SQOperator::str)
         .def("__repr__", &SQOperator::str);

--- a/src/qforte/sq_operator.h
+++ b/src/qforte/sq_operator.h
@@ -71,13 +71,33 @@ class SQOperator {
     // If B is nullptr, it computes products for A only.
     size_t count_unique_pauli_products(const SQOperator* B = nullptr) const;
 
+    // Returns the number of CNOT gates required to implement a single exponential
+    // Pauli rotations assuming linear connectivity, where the number of CNOTs is
+    // 2*(r-1), with r being the size of the contiguous qubit support.
+    int count_cnot_for_exponential();
+
     // Returns the number of CNOT gates required to implement the exponential
     // of a two-term anti-Hermitian SQOperator K of the form:
     //   K = i (g + g^)   or   K = g - g^
     // The circuit implementation is based on a standard decomposition for multi-qubit
     // Pauli rotations assuming linear connectivity, where the number of CNOTs is
     // 2*(r-1), with r being the size of the contiguous qubit support.
-    int count_cnot_for_exponential();
+    int count_cnot_for_exponential_full() const;
+
+    /**
+     * @brief Estimate the total number of T-gates required to implement
+     *        U = exp[K] for a two-term anti-Hermitian operator
+     *        K = g – g†  or  K = i(g + g†) under a surface-code,
+     *        to within approximation error ε.
+     *
+     * @param epsilon  Target diamond-norm (or spectral-norm) error for each
+     *                 single-qubit Rₙ(φ) synthesis. Typical values: 1e-3 … 1e-6.
+     * @return         Total T-gate count across all Pauli strings in the
+     *                 Jordan–Wigner expansion of g±g†.
+     * @throws std::invalid_argument if this SQOperator does not consist of exactly
+     *         two terms (i.e., K ≠ g±g†).
+     */
+    int count_T_for_exponential_full(double epsilon) const;
 
     /**
      * @brief Count the number of Pauli‐product terms resulting from the Jordan–Wigner


### PR DESCRIPTION
## Description
Adds full cnot counter and T counter to SQOperator class for exponentiation of operators of the form K = h(g - g^). The previous cnot counter in the SQOperator class would report the estimate for only a single Pauli term.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [ ] Ready to go!
