### PR TITLE
Adds in-place version of evolve pool trotter functions that do not re…

### DIFF
--- a/sandbox/fci_computer/applied_evolution_v2/test_evolv_2H_v3.py
+++ b/sandbox/fci_computer/applied_evolution_v2/test_evolv_2H_v3.py
@@ -1,0 +1,180 @@
+import qforte as qf
+import numpy as np
+ 
+import time
+
+# Define the reference and geometry lists.
+geom = [
+    ('H', (0., 0., 1.0)), 
+    ('H', (0., 0., 2.0)),
+    ('H', (0., 0., 3.0)), 
+    ('H', (0., 0., 4.0)),
+    ('H', (0., 0., 5.0)), 
+    ('H', (0., 0., 6.0)),
+    ('H', (0., 0., 7.0)), 
+    ('H', (0., 0., 8.0)),
+    ('H', (0., 0., 9.0)), 
+    ('H', (0., 0.,10.0)),
+    # ('H', (0., 0.,11.0)), 
+    # ('H', (0., 0.,12.0))
+    ]
+
+# Get the molecule object that now contains both the fermionic and qubit Hamiltonians.
+# mol = qf.system_factory(
+#     build_type='psi4', 
+#     mol_geometry=geom, 
+#     basis='sto-3g', 
+#     run_fci=1)
+
+mol = qf.system_factory(
+    build_type='psi4', 
+    mol_geometry=geom, 
+    basis='sto-3g', 
+    run_fci=0,
+    # build_qb_ham = False,
+    store_mo_ints=0,
+    build_df_ham=0,
+    df_icut=1.0e-6
+    )
+ 
+print("\n Initial FCIcomp Stuff")
+print("===========================")
+ref = mol.hf_reference
+
+nel = sum(ref)
+sz = 0
+norb = int(len(ref) / 2)
+
+print(f" nqbit:     {norb*2}")
+print(f" nel:       {nel}")
+ 
+fci_comp1 = qf.FCIComputer(nel=nel, sz=sz, norb=norb)
+fci_comp2 = qf.FCIComputer(nel=nel, sz=sz, norb=norb)
+
+# reference = 'random'
+reference = 'hf'
+
+if(reference == 'hf'):
+    fci_comp1.hartree_fock()
+    fci_comp2.hartree_fock()
+    
+
+# elif(reference == 'random'):
+#     np.random.seed(42)
+#     random_array = np.random.rand(fci_comp.get_state().shape()[0], fci_comp.get_state().shape()[1])
+#     random = np.array(random_array, dtype = np.dtype(np.complex128))
+
+#     Crand = qf.Tensor(fci_comp.get_state().shape(), "Crand")
+#     Crand.fill_from_nparray(random.ravel(), Crand.shape())
+#     rand_nrm = Crand.norm()
+#     Crand.scale(1/rand_nrm)
+
+#     fci_comp.set_state(Crand)
+    
+sqham = mol.sq_hamiltonian
+# sqham.simplify()
+
+hermitian_pairs = qf.SQOpPool()
+hermitian_pairs.add_hermitian_pairs(1.0, sqham)
+
+
+# print('sqham')
+# print(sqham)
+
+# print('hemitian_pairs')
+# print(hermitian_pairs)
+
+time = 0.1
+
+r = 1
+order = 1
+
+N = 4
+
+print(f"\n ===> Run parameters <=== \n")
+print(f"dt:    {time}")
+print(f"r:     {r}")
+print(f"order: {order}")
+print("")
+
+
+ty = qf.local_timer()
+
+print(f"\n ===> Running {N} time evolution steps <=== \n")
+for i in range(N):
+# Call Trotter for fci_comp1
+
+    ty.reset()
+
+    fci_comp1.evolve_pool_trotter(
+        hermitian_pairs,
+        time,
+        r,
+        order,
+        antiherm=False,
+        adjoint=False)
+
+    ty.record(f" Trotter step V1 {(i+1)} ")
+
+    ty.reset()
+
+    fci_comp2.evolve_pool_trotter_v2(
+        hermitian_pairs,
+        time,
+        r,
+        order,
+        antiherm=False,
+        adjoint=False)
+
+    ty.record(f" Trotter step V2 {(i+1)} ")
+
+
+    # print(fci_comp1.str(print_complex=False))
+    # print(fci_comp1.get_state().norm())
+
+    # Call full taylor evolution for fci_comp2
+    # fci_comp2.evolve_op_taylor(
+    #     sqham,
+    #     time,
+    #     1.0e-15,
+    #     30)
+
+    # print(fci_comp2)
+    # print(fci_comp2.get_state().norm())
+
+    C1 = fci_comp1.get_state_deep()
+    C2 = fci_comp2.get_state_deep()
+
+    C1.subtract(C2)
+
+    # # print(C1)
+    print(f" t: {(i+1)*time:6.6f} deltaC.norm() {C1.norm():6.6f}")
+
+# print(C1)
+
+print("")
+print(ty)
+
+#  output from v2
+
+#   Data:
+
+#                    0            1            2            3            4
+#       0   -0.5001063    0.0000000   -0.0002775    0.0044175    0.0000000
+#       1    0.0000000    0.1229534    0.0000000    0.0000000   -0.0538519
+#       2   -0.0005268    0.0000000    0.0738498   -0.0917071    0.0000000
+#       3    0.0039327    0.0000000   -0.0897774    0.0981957    0.0000000
+#       4    0.0000000   -0.0527863    0.0000000    0.0000000    0.0735297
+#       5    0.0373201    0.0000000    0.0060655   -0.0041627    0.0000000
+#                    5
+#       0    0.0373959
+#       1    0.0000000
+#       2    0.0061692
+#       3   -0.0041664
+#       4    0.0000000
+#       5   -0.0145490
+
+# not working rn, I suspect evolution is correct but formation of 
+# hermitian pairs might be funky for diagonal part of the
+# hamiltonain, or some such...
+

--- a/sandbox/srqk_fci_comp/test_v5_inplace_evo_alg.py
+++ b/sandbox/srqk_fci_comp/test_v5_inplace_evo_alg.py
@@ -1,0 +1,69 @@
+import qforte as qf
+
+
+geom = [
+    ('H', (0., 0., 1.00)), 
+    ('H', (0., 0., 2.00)),
+    ('H', (0., 0., 3.00)),
+    ('H', (0., 0., 4.00)),
+    ('H', (0., 0., 5.00)), 
+    ('H', (0., 0., 6.00)),
+    ('H', (0., 0., 7.00)),
+    ('H', (0., 0., 8.00)),
+    ('H', (0., 0., 9.00)),
+    ('H', (0., 0., 10.00))
+    ]
+
+ty = qf.local_timer()
+
+ty.reset()
+
+mol = qf.system_factory(
+    build_type='psi4', 
+    mol_geometry=geom, 
+    basis='sto-3g',
+    run_fci=1)
+
+ty.record("Psi 4 Molecule Setup")
+
+s = 5
+dt = 0.1
+
+# alg_fock = qf.SRQK(
+#     mol,
+#     computer_type = 'fock',
+#     trotter_number=4
+#     )
+
+# alg_fock.run(
+#     s=s,
+#     dt=dt
+# )
+
+# print(f'\n\n Efci:   {mol.fci_energy:+12.10f}')
+
+
+alg_fci = qf.SRQK(
+    mol,
+    computer_type = 'fci',
+    trotter_number=4
+    )
+
+ty.reset()
+
+alg_fci.run(
+    s=s,
+    dt=dt
+    )
+
+ty.record(f"SRQK FCI Computation")
+
+Egs = alg_fci.get_gs_energy()
+
+print('\n\n')
+print(f' Efci:   {mol.fci_energy:+12.10f}')
+print(f' Egs:    {Egs:+12.10f}')
+print(f' dE:     {Egs-mol.fci_energy:+12.10f}')
+
+print("")
+print(ty)

--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -287,7 +287,20 @@ PYBIND11_MODULE(qforte, m) {
             py::arg("antiherm") = false,
             py::arg("adjoint") = false
             )
+        .def("evolve_pool_trotter_basic_v2", &FCIComputer::evolve_pool_trotter_basic_v2, 
+            py::arg("sqop"),
+            py::arg("antiherm") = false,
+            py::arg("adjoint") = false
+            )
         .def("evolve_pool_trotter", &FCIComputer::evolve_pool_trotter, 
+            py::arg("sqop"),
+            py::arg("evolution_time"),
+            py::arg("trotter_steps"),
+            py::arg("trotter_order"),
+            py::arg("antiherm") = false,
+            py::arg("adjoint") = false
+            )
+        .def("evolve_pool_trotter_v2", &FCIComputer::evolve_pool_trotter_v2, 
             py::arg("sqop"),
             py::arg("evolution_time"),
             py::arg("trotter_steps"),

--- a/src/qforte/fci_computer.h
+++ b/src/qforte/fci_computer.h
@@ -246,6 +246,17 @@ class FCIComputer {
       const std::vector<int>& creb,
       const std::vector<int>& annb); 
 
+    /// Same as above but in-place (although the above is also in-place)
+    /// and Cin should be removed as an argument.
+    void evolve_individual_nbody_easy_v2(
+      const std::complex<double> time,
+      const std::complex<double> coeff,
+      Tensor& Cout,
+      const std::vector<int>& crea,
+      const std::vector<int>& anna,
+      const std::vector<int>& creb,
+      const std::vector<int>& annb); 
+
     /// A lower-level helper function that applies the exponential of a
     /// two-term (hermitian) SQOperator to the FCIComputer.
     /**
@@ -271,6 +282,15 @@ class FCIComputer {
       const std::complex<double> time,
       const std::complex<double> coeff,
       const Tensor& Cin,
+      Tensor& Cout,
+      const std::vector<int>& crea,
+      const std::vector<int>& anna,
+      const std::vector<int>& creb,
+      const std::vector<int>& annb);
+
+    void evolve_individual_nbody_hard_v2(
+      const std::complex<double> time,
+      const std::complex<double> coeff,
       Tensor& Cout,
       const std::vector<int>& crea,
       const std::vector<int>& anna,
@@ -310,11 +330,25 @@ class FCIComputer {
       const bool antiherm = false,
       const bool adjoint = false);
 
+    /// Same as above but all in-place for Cout
+    void evolve_individual_nbody_v2(
+      const std::complex<double> time,
+      const SQOperator& sqop,
+      Tensor& Cout,
+      const bool antiherm = false,
+      const bool adjoint = false);
+
     /// A function that applies the exponential of a
     /// two-term (hermitian) SQOperator to the FCIComputer.
     /// The operator is multipled by by the evolution time
     /// Onus on the user to assure evolution is unitary.
     void apply_sqop_evolution(
+      const std::complex<double> time,
+      const SQOperator& sqop,
+      const bool antiherm = false,
+      const bool adjoint = false);
+
+    void apply_sqop_evolution_v2(
       const std::complex<double> time,
       const SQOperator& sqop,
       const bool antiherm = false,
@@ -331,11 +365,25 @@ class FCIComputer {
       const bool antiherm = false,
       const bool adjoint = false);
 
+    /// Same as above but all inplace for C_
+    void evolve_pool_trotter_basic_v2(
+      const SQOpPool& pool,
+      const bool antiherm = false,
+      const bool adjoint = false);
+
     /// A more flexable function that applies the exponentials of an ordered list of
     /// two-term (hermitian) SQOperators to the FCIComputer
     /// Onus on the user to assure evolution is unitary.
     /// Primary use of this funcion is for dUCC ansatz
     void evolve_pool_trotter(
+      const SQOpPool& pool,
+      const double evolution_time,
+      const int trotter_steps,
+      const int trotter_order,
+      const bool antiherm = false,
+      const bool adjoint = false);
+
+    void evolve_pool_trotter_v2(
       const SQOpPool& pool,
       const double evolution_time,
       const int trotter_steps,


### PR DESCRIPTION
Adds in-place version of evolve pool trotter functions that do not require Cin. Combines all calls to the 4 subroutines into a single givens-like rotation. Observed speedup of about 4x for time evolution of H12 hamiltonian (even without pre-computing stp arrays on host side). 

benchmaks can be found in sandbox/fci_computer/applied_evolution_v2

The faster routine HAS NOT yet been plugged into algorithm class(s) on the python side, but a simple name swap in the bindings will accomplish this.


## Description
A brief description of the goals accomplished by this PR

## User Notes
- [x] Features added
- [x] Changes to compilation (if any)

## Checklist
- [x] Added/updated tests of new features
- [x] Removed comments in input files
- [x] Documented source code
- [x] Checked for redundant headers/imports
- [x] Checked for consistency in the formatting of the output file
- [x] Ready to go!
