### PR TITLE
Faster Singles and Doubles Pool Build

### DIFF
--- a/src/qforte/sq_op_pool.cc
+++ b/src/qforte/sq_op_pool.cc
@@ -758,85 +758,195 @@ void SQOpPool::fill_pool(std::string pool_type){
             throw std::invalid_argument( "Qforte UCC only supports up to Hextuple excitations." );
         }
 
-        int nqb = 2 * (nocc_ + nvir_);
-        int nel = 2 * nocc_;
-
-        // TODO(Nick): incorporate more flexibility into this
-        int na_el = nocc_;
-        int nb_el = nocc_;
-
-        for (int I=0; I<std::pow(2, nqb); I++) {
-
-            // get the basis state (I) | 11001100 > or whatever..
-            QubitBasis basis_I(I);
-
-            if(basis_I.get_num_ones() != na_el + nb_el) {
-                continue;
+        // Optimized implementation: directly enumerate valid excitations
+        // instead of iterating over all 2^nqb bitstrings
+        
+        // ============================================
+        // Singles (1-body excitations): i -> a
+        // ============================================
+        if (max_nbody >= 1) {
+            for (size_t i = 0; i < static_cast<size_t>(nocc_); i++) {
+                size_t ia = 2 * i;      // alpha occupied spin-orbital
+                size_t ib = 2 * i + 1;  // beta occupied spin-orbital
+                
+                for (size_t a = 0; a < static_cast<size_t>(nvir_); a++) {
+                    size_t aa = 2 * nocc_ + 2 * a;      // alpha virtual spin-orbital
+                    size_t ab = 2 * nocc_ + 2 * a + 1;  // beta virtual spin-orbital
+                    
+                    // Alpha single: i_α -> a_α (parity: +1 * +1 = +1)
+                    SQOperator t_a;
+                    t_a.add_term(+1.0, {aa}, {ia});
+                    t_a.add_term(-1.0, {ia}, {aa});
+                    t_a.simplify();
+                    if (t_a.terms().size() > 0) {
+                        add_term(1.0, t_a);
+                    }
+                    
+                    // Beta single: i_β -> a_β (parity: -1 * -1 = +1)
+                    SQOperator t_b;
+                    t_b.add_term(+1.0, {ab}, {ib});
+                    t_b.add_term(-1.0, {ib}, {ab});
+                    t_b.simplify();
+                    if (t_b.terms().size() > 0) {
+                        add_term(1.0, t_b);
+                    }
+                }
             }
+        }
+        
+        // ============================================
+        // Doubles (2-body excitations): i,j -> a,b
+        // ============================================
+        if (max_nbody >= 2) {
+            for (size_t i = 0; i < static_cast<size_t>(nocc_); i++) {
+                size_t ia = 2 * i;
+                size_t ib = 2 * i + 1;
+                
+                for (size_t j = i; j < static_cast<size_t>(nocc_); j++) {
+                    size_t ja = 2 * j;
+                    size_t jb = 2 * j + 1;
+                    
+                    for (size_t a = 0; a < static_cast<size_t>(nvir_); a++) {
+                        size_t aa = 2 * nocc_ + 2 * a;
+                        size_t ab = 2 * nocc_ + 2 * a + 1;
+                        
+                        for (size_t b = a; b < static_cast<size_t>(nvir_); b++) {
+                            size_t ba = 2 * nocc_ + 2 * b;
+                            size_t bb = 2 * nocc_ + 2 * b + 1;
+                            
+                            // αα -> αα: (i_α, j_α) -> (a_α, b_α)
+                            // parity: (+1)(+1)(+1)(+1) = +1
+                            if (i != j && a != b) {
+                                SQOperator t_aaaa;
+                                t_aaaa.add_term(+1.0, {aa, ba}, {ia, ja});
+                                t_aaaa.add_term(-1.0, {ja, ia}, {ba, aa});
+                                t_aaaa.simplify();
+                                if (t_aaaa.terms().size() > 0) {
+                                    add_term(1.0, t_aaaa);
+                                }
+                            }
+                            
+                            // ββ -> ββ: (i_β, j_β) -> (a_β, b_β)
+                            // parity: (-1)(-1)(-1)(-1) = +1
+                            if (i != j && a != b) {
+                                SQOperator t_bbbb;
+                                t_bbbb.add_term(+1.0, {ab, bb}, {ib, jb});
+                                t_bbbb.add_term(-1.0, {jb, ib}, {bb, ab});
+                                t_bbbb.simplify();
+                                if (t_bbbb.terms().size() > 0) {
+                                    add_term(1.0, t_bbbb);
+                                }
+                            }
+                            
+                            // αβ -> αβ: (i_α, j_β) -> (a_α, b_β)
+                            // parity: (+1)(-1)(+1)(-1) = +1
+                            {
+                                SQOperator t_abab;
+                                t_abab.add_term(+1.0, {aa, bb}, {ia, jb});
+                                t_abab.add_term(-1.0, {jb, ia}, {bb, aa});
+                                t_abab.simplify();
+                                if (t_abab.terms().size() > 0) {
+                                    add_term(1.0, t_abab);
+                                }
+                            }
+                            
+                            // βα -> βα: (i_β, j_α) -> (a_β, b_α)
+                            // parity: (-1)(+1)(-1)(+1) = +1
+                            // Skip if same spatial orbitals to avoid duplicates with αβ->αβ
+                            if (i != j || a != b) {
+                                SQOperator t_baba;
+                                t_baba.add_term(+1.0, {ab, ba}, {ib, ja});
+                                t_baba.add_term(-1.0, {ja, ib}, {ba, ab});
+                                t_baba.simplify();
+                                if (t_baba.terms().size() > 0) {
+                                    add_term(1.0, t_baba);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        // ============================================
+        // Triples and higher (3+ body excitations)
+        // Fall back to enumeration for these less common cases
+        // ============================================
+        if (max_nbody >= 3) {
+            int nqb = 2 * (nocc_ + nvir_);
+            int nel = 2 * nocc_;
+            int na_el = nocc_;
+            int nb_el = nocc_;
 
-            int nbody = 0;
-            int pn = 0;
-            int na_I = 0;
-            int nb_I = 0;
-            std::vector<size_t> holes; // i, j, k, ...
-            std::vector<size_t> particles; // a, b, c, ...
-            std::vector<int> parity;
+            for (int I = 0; I < std::pow(2, nqb); I++) {
+                QubitBasis basis_I(I);
 
-            for (size_t p=0; p<2*nocc_; p++) {
-                int bit_val = static_cast<int>(basis_I.get_bit(p));
-                nbody += ( 1 - bit_val);
-                pn += bit_val;
-                if(p%2==0){
-                    na_I += bit_val;
-                } else {
-                    nb_I += bit_val;
+                if (basis_I.get_num_ones() != na_el + nb_el) {
+                    continue;
                 }
 
-                if(bit_val-1){
-                    holes.push_back(p);
-                    if(p%2==0){
-                        parity.push_back(1);
+                int nbody = 0;
+                int pn = 0;
+                int na_I = 0;
+                int nb_I = 0;
+                std::vector<size_t> holes;
+                std::vector<size_t> particles;
+                std::vector<int> parity;
+
+                for (size_t p = 0; p < 2 * static_cast<size_t>(nocc_); p++) {
+                    int bit_val = static_cast<int>(basis_I.get_bit(p));
+                    nbody += (1 - bit_val);
+                    pn += bit_val;
+                    if (p % 2 == 0) {
+                        na_I += bit_val;
                     } else {
-                        parity.push_back(-1);
+                        nb_I += bit_val;
+                    }
+
+                    if (bit_val - 1) {
+                        holes.push_back(p);
+                        if (p % 2 == 0) {
+                            parity.push_back(1);
+                        } else {
+                            parity.push_back(-1);
+                        }
                     }
                 }
-            }
-            for (size_t q=2*nocc_; q<nqb; q++) {
-                int bit_val = static_cast<int>(basis_I.get_bit(q));
-                pn += bit_val;
-                if(q%2==0){
-                    na_I += bit_val;
-                } else {
-                    nb_I += bit_val;
-                }
-                if(bit_val){
-                    particles.push_back(q);
-                    if(q%2==0){
-                        parity.push_back(1);
+                for (size_t q = 2 * static_cast<size_t>(nocc_); q < static_cast<size_t>(nqb); q++) {
+                    int bit_val = static_cast<int>(basis_I.get_bit(q));
+                    pn += bit_val;
+                    if (q % 2 == 0) {
+                        na_I += bit_val;
                     } else {
-                        parity.push_back(-1);
+                        nb_I += bit_val;
+                    }
+                    if (bit_val) {
+                        particles.push_back(q);
+                        if (q % 2 == 0) {
+                            parity.push_back(1);
+                        } else {
+                            parity.push_back(-1);
+                        }
                     }
                 }
-            }
 
-            if(pn==nel && na_I == na_el && nb_I == nb_el){
+                if (pn == nel && na_I == na_el && nb_I == nb_el) {
+                    // Only process triples and higher (singles/doubles already handled)
+                    if (nbody >= 3 && nbody <= max_nbody) {
+                        int total_parity = 1;
+                        for (const auto& z : parity) {
+                            total_parity *= z;
+                        }
 
-                if (nbody != 0 && nbody <= max_nbody ) {
-
-                    int total_parity = 1;
-                    for (const auto& z: parity){
-                        total_parity *= z;
-                    }
-
-                    if(total_parity==1){
-                        // need i, j, a, b
-                        SQOperator t_temp;
-                        t_temp.add_term(+1.0, particles, holes);
-                        std::vector<size_t> rparticles(particles.rbegin(), particles.rend());
-                        std::vector<size_t> rholes(holes.rbegin(), holes.rend());
-                        t_temp.add_term(-1.0, rholes, rparticles);
-                        t_temp.simplify();
-                        add_term(1.0, t_temp);
+                        if (total_parity == 1) {
+                            SQOperator t_temp;
+                            t_temp.add_term(+1.0, particles, holes);
+                            std::vector<size_t> rparticles(particles.rbegin(), particles.rend());
+                            std::vector<size_t> rholes(holes.rbegin(), holes.rend());
+                            t_temp.add_term(-1.0, rholes, rparticles);
+                            t_temp.simplify();
+                            add_term(1.0, t_temp);
+                        }
                     }
                 }
             }

--- a/src/qforte/sq_op_pool_gpu.cu
+++ b/src/qforte/sq_op_pool_gpu.cu
@@ -352,85 +352,195 @@ void SQOpPoolGPU::fill_pool(std::string pool_type){
             throw std::invalid_argument( "Qforte UCC only supports up to Hextuple excitations." );
         }
 
-        int nqb = 2 * (nocc_ + nvir_);
-        int nel = 2 * nocc_;
-
-        // TODO(Nick): incorporate more flexibility into this
-        int na_el = nocc_;
-        int nb_el = nocc_;
-
-        for (int I=0; I<std::pow(2, nqb); I++) {
-
-            // get the basis state (I) | 11001100 > or whatever..
-            QubitBasis basis_I(I);
-
-            if(basis_I.get_num_ones() != na_el + nb_el) {
-                continue;
+        // Optimized implementation: directly enumerate valid excitations
+        // instead of iterating over all 2^nqb bitstrings
+        
+        // ============================================
+        // Singles (1-body excitations): i -> a
+        // ============================================
+        if (max_nbody >= 1) {
+            for (size_t i = 0; i < static_cast<size_t>(nocc_); i++) {
+                size_t ia = 2 * i;      // alpha occupied spin-orbital
+                size_t ib = 2 * i + 1;  // beta occupied spin-orbital
+                
+                for (size_t a = 0; a < static_cast<size_t>(nvir_); a++) {
+                    size_t aa = 2 * nocc_ + 2 * a;      // alpha virtual spin-orbital
+                    size_t ab = 2 * nocc_ + 2 * a + 1;  // beta virtual spin-orbital
+                    
+                    // Alpha single: i_α -> a_α (parity: +1 * +1 = +1)
+                    SQOperator t_a;
+                    t_a.add_term(+1.0, {aa}, {ia});
+                    t_a.add_term(-1.0, {ia}, {aa});
+                    t_a.simplify();
+                    if (t_a.terms().size() > 0) {
+                        add_term(1.0, t_a);
+                    }
+                    
+                    // Beta single: i_β -> a_β (parity: -1 * -1 = +1)
+                    SQOperator t_b;
+                    t_b.add_term(+1.0, {ab}, {ib});
+                    t_b.add_term(-1.0, {ib}, {ab});
+                    t_b.simplify();
+                    if (t_b.terms().size() > 0) {
+                        add_term(1.0, t_b);
+                    }
+                }
             }
+        }
+        
+        // ============================================
+        // Doubles (2-body excitations): i,j -> a,b
+        // ============================================
+        if (max_nbody >= 2) {
+            for (size_t i = 0; i < static_cast<size_t>(nocc_); i++) {
+                size_t ia = 2 * i;
+                size_t ib = 2 * i + 1;
+                
+                for (size_t j = i; j < static_cast<size_t>(nocc_); j++) {
+                    size_t ja = 2 * j;
+                    size_t jb = 2 * j + 1;
+                    
+                    for (size_t a = 0; a < static_cast<size_t>(nvir_); a++) {
+                        size_t aa = 2 * nocc_ + 2 * a;
+                        size_t ab = 2 * nocc_ + 2 * a + 1;
+                        
+                        for (size_t b = a; b < static_cast<size_t>(nvir_); b++) {
+                            size_t ba = 2 * nocc_ + 2 * b;
+                            size_t bb = 2 * nocc_ + 2 * b + 1;
+                            
+                            // αα -> αα: (i_α, j_α) -> (a_α, b_α)
+                            // parity: (+1)(+1)(+1)(+1) = +1
+                            if (i != j && a != b) {
+                                SQOperator t_aaaa;
+                                t_aaaa.add_term(+1.0, {aa, ba}, {ia, ja});
+                                t_aaaa.add_term(-1.0, {ja, ia}, {ba, aa});
+                                t_aaaa.simplify();
+                                if (t_aaaa.terms().size() > 0) {
+                                    add_term(1.0, t_aaaa);
+                                }
+                            }
+                            
+                            // ββ -> ββ: (i_β, j_β) -> (a_β, b_β)
+                            // parity: (-1)(-1)(-1)(-1) = +1
+                            if (i != j && a != b) {
+                                SQOperator t_bbbb;
+                                t_bbbb.add_term(+1.0, {ab, bb}, {ib, jb});
+                                t_bbbb.add_term(-1.0, {jb, ib}, {bb, ab});
+                                t_bbbb.simplify();
+                                if (t_bbbb.terms().size() > 0) {
+                                    add_term(1.0, t_bbbb);
+                                }
+                            }
+                            
+                            // αβ -> αβ: (i_α, j_β) -> (a_α, b_β)
+                            // parity: (+1)(-1)(+1)(-1) = +1
+                            {
+                                SQOperator t_abab;
+                                t_abab.add_term(+1.0, {aa, bb}, {ia, jb});
+                                t_abab.add_term(-1.0, {jb, ia}, {bb, aa});
+                                t_abab.simplify();
+                                if (t_abab.terms().size() > 0) {
+                                    add_term(1.0, t_abab);
+                                }
+                            }
+                            
+                            // βα -> βα: (i_β, j_α) -> (a_β, b_α)
+                            // parity: (-1)(+1)(-1)(+1) = +1
+                            // Skip if same spatial orbitals to avoid duplicates with αβ->αβ
+                            if (i != j || a != b) {
+                                SQOperator t_baba;
+                                t_baba.add_term(+1.0, {ab, ba}, {ib, ja});
+                                t_baba.add_term(-1.0, {ja, ib}, {ba, ab});
+                                t_baba.simplify();
+                                if (t_baba.terms().size() > 0) {
+                                    add_term(1.0, t_baba);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        // ============================================
+        // Triples and higher (3+ body excitations)
+        // Fall back to enumeration for these less common cases
+        // ============================================
+        if (max_nbody >= 3) {
+            int nqb = 2 * (nocc_ + nvir_);
+            int nel = 2 * nocc_;
+            int na_el = nocc_;
+            int nb_el = nocc_;
 
-            int nbody = 0;
-            int pn = 0;
-            int na_I = 0;
-            int nb_I = 0;
-            std::vector<size_t> holes; // i, j, k, ...
-            std::vector<size_t> particles; // a, b, c, ...
-            std::vector<int> parity;
+            for (int I = 0; I < std::pow(2, nqb); I++) {
+                QubitBasis basis_I(I);
 
-            for (size_t p=0; p<2*nocc_; p++) {
-                int bit_val = static_cast<int>(basis_I.get_bit(p));
-                nbody += ( 1 - bit_val);
-                pn += bit_val;
-                if(p%2==0){
-                    na_I += bit_val;
-                } else {
-                    nb_I += bit_val;
+                if (basis_I.get_num_ones() != na_el + nb_el) {
+                    continue;
                 }
 
-                if(bit_val-1){
-                    holes.push_back(p);
-                    if(p%2==0){
-                        parity.push_back(1);
+                int nbody = 0;
+                int pn = 0;
+                int na_I = 0;
+                int nb_I = 0;
+                std::vector<size_t> holes;
+                std::vector<size_t> particles;
+                std::vector<int> parity;
+
+                for (size_t p = 0; p < 2 * static_cast<size_t>(nocc_); p++) {
+                    int bit_val = static_cast<int>(basis_I.get_bit(p));
+                    nbody += (1 - bit_val);
+                    pn += bit_val;
+                    if (p % 2 == 0) {
+                        na_I += bit_val;
                     } else {
-                        parity.push_back(-1);
+                        nb_I += bit_val;
+                    }
+
+                    if (bit_val - 1) {
+                        holes.push_back(p);
+                        if (p % 2 == 0) {
+                            parity.push_back(1);
+                        } else {
+                            parity.push_back(-1);
+                        }
                     }
                 }
-            }
-            for (size_t q=2*nocc_; q<nqb; q++) {
-                int bit_val = static_cast<int>(basis_I.get_bit(q));
-                pn += bit_val;
-                if(q%2==0){
-                    na_I += bit_val;
-                } else {
-                    nb_I += bit_val;
-                }
-                if(bit_val){
-                    particles.push_back(q);
-                    if(q%2==0){
-                        parity.push_back(1);
+                for (size_t q = 2 * static_cast<size_t>(nocc_); q < static_cast<size_t>(nqb); q++) {
+                    int bit_val = static_cast<int>(basis_I.get_bit(q));
+                    pn += bit_val;
+                    if (q % 2 == 0) {
+                        na_I += bit_val;
                     } else {
-                        parity.push_back(-1);
+                        nb_I += bit_val;
+                    }
+                    if (bit_val) {
+                        particles.push_back(q);
+                        if (q % 2 == 0) {
+                            parity.push_back(1);
+                        } else {
+                            parity.push_back(-1);
+                        }
                     }
                 }
-            }
 
-            if(pn==nel && na_I == na_el && nb_I == nb_el){
+                if (pn == nel && na_I == na_el && nb_I == nb_el) {
+                    // Only process triples and higher (singles/doubles already handled)
+                    if (nbody >= 3 && nbody <= max_nbody) {
+                        int total_parity = 1;
+                        for (const auto& z : parity) {
+                            total_parity *= z;
+                        }
 
-                if (nbody != 0 && nbody <= max_nbody ) {
-
-                    int total_parity = 1;
-                    for (const auto& z: parity){
-                        total_parity *= z;
-                    }
-
-                    if(total_parity==1){
-                        // need i, j, a, b
-                        SQOperator t_temp;
-                        t_temp.add_term(+1.0, particles, holes);
-                        std::vector<size_t> rparticles(particles.rbegin(), particles.rend());
-                        std::vector<size_t> rholes(holes.rbegin(), holes.rend());
-                        t_temp.add_term(-1.0, rholes, rparticles);
-                        t_temp.simplify();
-                        add_term(1.0, t_temp);
+                        if (total_parity == 1) {
+                            SQOperator t_temp;
+                            t_temp.add_term(+1.0, particles, holes);
+                            std::vector<size_t> rparticles(particles.rbegin(), particles.rend());
+                            std::vector<size_t> rholes(holes.rbegin(), holes.rend());
+                            t_temp.add_term(-1.0, rholes, rparticles);
+                            t_temp.simplify();
+                            add_term(1.0, t_temp);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description
I removed the old Singles and doubles build code that iterated over every possible bitstring and replaced it with code that just enumerates the specific UCCSD style excitations. Not sure if this is quite what we were going for, but it's much faster and the tensor diff with fqe is still < 1e-14.